### PR TITLE
add include to zon file

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -74,6 +74,7 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "include",
         // For example...
         //"LICENSE",
         //"README.md",


### PR DESCRIPTION
The include directory was missing from the build.zig.zon, which prevented zig from finding the include/ files necessary for building.  This fixes normal zig/zon dependency usage.