### PR TITLE
fix: `zlob_at` walker relative directory opens

### DIFF
--- a/src/walker.zig
+++ b/src/walker.zig
@@ -922,8 +922,9 @@ pub const DirIterator = struct {
             };
         }
 
-        // On Windows or when libc is not available, use std.fs
-        if (builtin.os.tag == .windows or !has_libc) {
+        // When base_dir is set (need relative opens) or on Windows or when libc
+        // is not available, use std.fs
+        if (base_dir != null or builtin.os.tag == .windows or !has_libc) {
             const root = base_dir orelse std.fs.cwd();
             var dir = try root.openDir(path, .{ .iterate = true });
             return DirIterator{

--- a/test/test_c_api.c
+++ b/test/test_c_api.c
@@ -1,7 +1,9 @@
 #include "zlob.h"
 #include <assert.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #define TEST(name) printf("  [TEST] %s\n", name)
 #define PASS() printf("    ✓ PASS\n")
@@ -76,6 +78,57 @@ int main(void) {
     } else {
       FAIL("zlob() returned error");
     }
+  }
+
+  printf("\nzlob_at() - Filesystem Walking Relative to Base Directory\n");
+  TEST("Match relative patterns from absolute base path");
+  {
+    char src_base[4096];
+    char repo_root[4096];
+
+    if (realpath("src", src_base) == NULL)
+      FAIL("realpath(src) failed");
+    if (realpath(".", repo_root) == NULL)
+      FAIL("realpath(.) failed");
+
+    zlob_t pzlob;
+    int result = zlob_at(src_base, "*.zig", 0, NULL, &pzlob);
+
+    if (result != 0)
+      FAIL("zlob_at() failed for *.zig");
+    if (pzlob.zlo_pathc == 0)
+      FAIL("Expected at least one match for *.zig");
+
+    int found_walker = 0;
+    int found_flags = 0;
+    for (size_t i = 0; i < pzlob.zlo_pathc; i++) {
+      if (strcmp(pzlob.zlo_pathv[i], "walker.zig") == 0)
+        found_walker = 1;
+      if (strcmp(pzlob.zlo_pathv[i], "flags.zig") == 0)
+        found_flags = 1;
+    }
+    if (!found_walker || !found_flags)
+      FAIL("Expected relative matches walker.zig and flags.zig");
+
+    zlobfree(&pzlob);
+
+    result = zlob_at(repo_root, "src/*.zig", 0, NULL, &pzlob);
+    if (result != 0)
+      FAIL("zlob_at() failed for src/*.zig");
+
+    found_walker = 0;
+    found_flags = 0;
+    for (size_t i = 0; i < pzlob.zlo_pathc; i++) {
+      if (strcmp(pzlob.zlo_pathv[i], "src/walker.zig") == 0)
+        found_walker = 1;
+      if (strcmp(pzlob.zlo_pathv[i], "src/flags.zig") == 0)
+        found_flags = 1;
+    }
+    if (!found_walker || !found_flags)
+      FAIL("Expected relative matches src/walker.zig and src/flags.zig");
+
+    zlobfree(&pzlob);
+    PASS();
   }
 
   // zlob_match_paths() - Path filtering (no filesystem)


### PR DESCRIPTION
The libc single dir iterator ignored `base_dir`
and used `opendir()` from the process cwd, which
broke `zlob_at()` API for relative non-recursive
patterns.

Route `base_dir` backed opens thru `std.fs.openDir()`.

Fixes #7

**Proof**:

Same as #7:

```console
$ /tmp/repro_zlob_at
Using base path: /home/dw1/Development/zlob/testdata
zlob(/home/dw1/Development/zlob/testdata/*.txt) -> rc=0 count=2
  [0] /home/dw1/Development/zlob/testdata/alpha.txt
  [1] /home/dw1/Development/zlob/testdata/file.txt
zlob_at(base=/home/dw1/Development/zlob/testdata, pattern=*.txt) -> rc=0 count=2
  [0] alpha.txt
  [1] file.txt
zlob(/home/dw1/Development/zlob/testdata/nested/*.txt) -> rc=0 count=1
  [0] /home/dw1/Development/zlob/testdata/nested/gamma.txt
zlob_at(base=/home/dw1/Development/zlob/testdata, pattern=nested/*.txt) -> rc=0 count=1
  [0] nested/gamma.txt
```