### PR TITLE
feat: migrate to zig 0.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  ZIG_VERSION: "0.15.2"
+  ZIG_VERSION: "0.16.0"
 
 jobs:
   linux:

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ uninstall:
 	fi
 	@echo "Uninstall complete!"
 
-# Minimal test of C API
-test: build test/test_c_api.c
+test: build
+	zig build test --summary all
 	$(CC) $(CFLAGS) -I./zig-out/include -L./zig-out/lib \
 		-o test_c_api test/test_c_api.c -lzlob \
 		-Wl,-rpath,./zig-out/lib

--- a/bench/bench_brace.zig
+++ b/bench/bench_brace.zig
@@ -1,9 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const c_lib = @import("c_lib");
 const zlob_flags = @import("zlob_flags");
 const zlob_t = c_lib.zlob_t;
-
-const Timer = std.time.Timer;
 
 const TestCase = struct {
     name: []const u8,
@@ -44,16 +43,21 @@ const BenchmarkResult = struct {
 };
 
 fn getRepoPath(allocator: std.mem.Allocator) ![]const u8 {
-    // Try PROFILE_BIG_REPO env var first
-    if (std.process.getEnvVarOwned(allocator, "PROFILE_BIG_REPO")) |path| {
-        return path;
-    } else |_| {
-        // Fallback to default path
-        return try allocator.dupe(u8, "/Users/neogoose/dev/lightsource");
+    // Try PROFILE_BIG_REPO env var first (via libc getenv)
+    if (builtin.link_libc) {
+        const name_z = try allocator.dupeZ(u8, "PROFILE_BIG_REPO");
+        defer allocator.free(name_z);
+        if (std.c.getenv(name_z.ptr)) |val| {
+            const slice = std.mem.sliceTo(val, 0);
+            return try allocator.dupe(u8, slice);
+        }
     }
+    // Fallback to default path
+    return try allocator.dupe(u8, "/Users/neogoose/dev/lightsource");
 }
 
 fn runBenchmark(tc: TestCase, warmup_iterations: usize) !BenchmarkResult {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const flags: c_int = zlob_flags.ZLOB_RECOMMENDED | zlob_flags.ZLOB_GITIGNORE;
     var matches: usize = 0;
     for (0..warmup_iterations) |_| {
@@ -66,8 +70,7 @@ fn runBenchmark(tc: TestCase, warmup_iterations: usize) !BenchmarkResult {
     }
 
     // Timed benchmark runs
-    var timer = try Timer.start();
-    const start = timer.read();
+    const start = std.Io.Timestamp.now(io, .awake);
 
     for (0..tc.iterations) |_| {
         var pzlob: zlob_t = undefined;
@@ -78,8 +81,8 @@ fn runBenchmark(tc: TestCase, warmup_iterations: usize) !BenchmarkResult {
         }
     }
 
-    const end = timer.read();
-    const elapsed_ns = end - start;
+    const end = std.Io.Timestamp.now(io, .awake);
+    const elapsed_ns: u64 = @intCast(start.durationTo(end).nanoseconds);
     const avg_ns = elapsed_ns / tc.iterations;
 
     return BenchmarkResult{
@@ -109,6 +112,7 @@ fn printResult(result: BenchmarkResult) void {
 }
 
 pub fn main() !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const allocator = std.heap.c_allocator;
 
     // Get repository path
@@ -116,7 +120,7 @@ pub fn main() !void {
     defer allocator.free(repo_path);
 
     // Change to repository directory
-    std.posix.chdir(repo_path) catch |err| {
+    std.process.setCurrentPath(io, repo_path) catch |err| {
         std.debug.print("Error: Cannot change to directory '{s}': {}\n", .{ repo_path, err });
         std.debug.print("\nSet PROFILE_BIG_REPO environment variable to a valid repository path.\n", .{});
         std.debug.print("Example: PROFILE_BIG_REPO=/path/to/repo zig build bench-brace -Doptimize=ReleaseFast\n", .{});
@@ -237,7 +241,7 @@ pub fn main() !void {
         printResult(results[i]);
 
         // Small pause between tests
-        std.Thread.sleep(50 * std.time.ns_per_ms);
+        std.Io.sleep(io, std.Io.Duration.fromNanoseconds(50 * std.time.ns_per_ms), .awake) catch {};
     }
 
     std.debug.print("\n========================================\n", .{});

--- a/bench/bench_fnmatch.zig
+++ b/bench/bench_fnmatch.zig
@@ -16,18 +16,21 @@ const ITERATIONS = 1_000_000;
 const WARMUP = 100;
 
 fn benchmark(comptime label: []const u8, comptime func: anytype) void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+
     // Warmup
     for (0..WARMUP) |_| {
         std.mem.doNotOptimizeAway(func());
     }
 
-    const start = std.time.nanoTimestamp();
+    const start = std.Io.Timestamp.now(io, .awake);
     for (0..ITERATIONS) |_| {
         std.mem.doNotOptimizeAway(func());
     }
-    const end = std.time.nanoTimestamp();
+    const end = std.Io.Timestamp.now(io, .awake);
 
-    const elapsed_ns: f64 = @floatFromInt(end - start);
+    const elapsed_u64: u64 = @intCast(start.durationTo(end).nanoseconds);
+    const elapsed_ns: f64 = @floatFromInt(elapsed_u64);
     const per_op = elapsed_ns / @as(f64, ITERATIONS);
     const ops_per_sec = @as(f64, ITERATIONS) / (elapsed_ns / 1_000_000_000.0);
     std.debug.print("  {s:<45} {d:>8.1}ns/op  {d:>10.0} ops/s\n", .{ label, per_op, ops_per_sec });

--- a/bench/bench_matchPaths.zig
+++ b/bench/bench_matchPaths.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const time = std.time;
 
 const zlob = @import("zlob");
 
@@ -13,6 +12,8 @@ fn benchmark(
     pattern: []const u8,
     paths: []const []const u8,
 ) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+
     // Warmup
     for (0..WARMUP_ITERATIONS) |_| {
         var result = try zlob.matchPaths(allocator, pattern, paths, zlob.ZlobFlags.recommended());
@@ -20,14 +21,14 @@ fn benchmark(
     }
 
     // Actual benchmark
-    const start = time.nanoTimestamp();
+    const start = std.Io.Timestamp.now(io, .awake);
     for (0..ITERATIONS) |_| {
         var result = try zlob.matchPaths(allocator, pattern, paths, 0);
         result.deinit();
     }
-    const end = time.nanoTimestamp();
+    const end = std.Io.Timestamp.now(io, .awake);
 
-    const total_ns = @as(u64, @intCast(end - start));
+    const total_ns: u64 = @intCast(start.durationTo(end).nanoseconds);
     const avg_ns = total_ns / ITERATIONS;
     const avg_us = avg_ns / 1000;
 
@@ -48,6 +49,7 @@ fn benchmarkWithBrace(
     pattern: []const u8,
     paths: []const []const u8,
 ) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const flags = zlob.ZlobFlags.recommended().with(.{ .brace = true });
 
     // Warmup
@@ -57,14 +59,14 @@ fn benchmarkWithBrace(
     }
 
     // Actual benchmark
-    const start = time.nanoTimestamp();
+    const start = std.Io.Timestamp.now(io, .awake);
     for (0..ITERATIONS) |_| {
         var result = try zlob.matchPaths(allocator, pattern, paths, flags);
         result.deinit();
     }
-    const end = time.nanoTimestamp();
+    const end = std.Io.Timestamp.now(io, .awake);
 
-    const total_ns = @as(u64, @intCast(end - start));
+    const total_ns: u64 = @intCast(start.durationTo(end).nanoseconds);
     const avg_ns = total_ns / ITERATIONS;
     const avg_us = avg_ns / 1000;
 
@@ -80,9 +82,9 @@ fn benchmarkWithBrace(
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+    var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = debug_allocator.deinit();
+    const allocator = debug_allocator.allocator();
 
     std.debug.print("\n=== Pattern Matching Benchmarks ===\n\n", .{});
     std.debug.print("{s:50} | {s:13} | {s}\n", .{ "Benchmark", "Time", "Matches" });

--- a/bench/bench_multi_suffix.zig
+++ b/bench/bench_multi_suffix.zig
@@ -78,6 +78,7 @@ fn runBenchmark(
     comptime name: []const u8,
     comptime patterns: []const []const u8,
 ) void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const contexts = createContexts(patterns);
     const unified = suffix_match.UnifiedMultiSuffix.init(&contexts);
 
@@ -95,24 +96,24 @@ fn runBenchmark(
     matches_unified = 0;
 
     // Benchmark original approach
-    const start1 = std.time.nanoTimestamp();
+    const start1 = std.Io.Timestamp.now(io, .awake);
     for (0..ITERATIONS) |_| {
         for (test_filenames) |filename| {
             if (matchOriginal(filename, &contexts)) matches_original += 1;
         }
     }
-    const end1 = std.time.nanoTimestamp();
-    const original_ns: u64 = @intCast(end1 - start1);
+    const end1 = std.Io.Timestamp.now(io, .awake);
+    const original_ns: u64 = @intCast(start1.durationTo(end1).nanoseconds);
 
     // Benchmark unified approach
-    const start2 = std.time.nanoTimestamp();
+    const start2 = std.Io.Timestamp.now(io, .awake);
     for (0..ITERATIONS) |_| {
         for (test_filenames) |filename| {
             if (matchUnified(filename, &unified)) matches_unified += 1;
         }
     }
-    const end2 = std.time.nanoTimestamp();
-    const unified_ns: u64 = @intCast(end2 - start2);
+    const end2 = std.Io.Timestamp.now(io, .awake);
+    const unified_ns: u64 = @intCast(start2.durationTo(end2).nanoseconds);
 
     const total_ops = ITERATIONS * test_filenames.len;
     const original_ns_per_op = @as(f64, @floatFromInt(original_ns)) / @as(f64, @floatFromInt(total_ops));

--- a/bench/bench_tree_sizes.zig
+++ b/bench/bench_tree_sizes.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const c_lib = @import("c_lib");
 const zlob_flags = @import("zlob_flags");
-const posix = std.posix;
-const Timer = std.time.Timer;
 
 // libc glob types and functions
 extern "c" fn glob(pattern: [*:0]const u8, flags: c_int, errfunc: ?*const anyopaque, pglob: *LibcGlobT) c_int;
@@ -16,17 +14,17 @@ const LibcGlobT = extern struct {
 
 // --- Tree creation helpers ---
 
-fn createFile(dir: std.fs.Dir, path: []const u8) void {
+fn createFile(io: std.Io, dir: std.Io.Dir, path: []const u8) void {
     // Create parent directories if needed
     if (std.fs.path.dirname(path)) |parent| {
-        dir.makePath(parent) catch {};
+        dir.createDirPath(io, parent) catch {};
     }
-    const f = dir.createFile(path, .{}) catch return;
-    f.close();
+    const f = dir.createFile(io, path, .{}) catch return;
+    f.close(io);
 }
 
-fn createDir(dir: std.fs.Dir, path: []const u8) void {
-    dir.makePath(path) catch {};
+fn createDir(io: std.Io, dir: std.Io.Dir, path: []const u8) void {
+    dir.createDirPath(io, path) catch {};
 }
 
 const TreeConfig = struct {
@@ -133,17 +131,17 @@ const medium_tree = TreeConfig{
     .files = &medium_files_array,
 };
 
-fn buildTree(base: std.fs.Dir, config: TreeConfig) void {
+fn buildTree(io: std.Io, base: std.Io.Dir, config: TreeConfig) void {
     for (config.dirs) |d| {
-        createDir(base, d);
+        createDir(io, base, d);
     }
     for (config.files) |f| {
-        createFile(base, f);
+        createFile(io, base, f);
     }
 }
 
 /// Build a large tree programmatically: ~5000 files across ~200 dirs
-fn buildLargeTree(base: std.fs.Dir) void {
+fn buildLargeTree(io: std.Io, base: std.Io.Dir) void {
     const top_dirs = [_][]const u8{
         "src", "lib", "test", "docs", "bench", "tools", "scripts", "config", "data", "assets",
     };
@@ -164,11 +162,11 @@ fn buildLargeTree(base: std.fs.Dir) void {
 
     // Create directory structure
     for (top_dirs) |top| {
-        createDir(base, top);
+        createDir(io, base, top);
         for (sub_dirs) |sub| {
             var buf: [256]u8 = undefined;
             const path = std.fmt.bufPrint(&buf, "{s}/{s}", .{ top, sub }) catch continue;
-            createDir(base, path);
+            createDir(io, base, path);
         }
     }
 
@@ -180,7 +178,7 @@ fn buildLargeTree(base: std.fs.Dir) void {
                 const ext = exts[count % exts.len];
                 var buf: [512]u8 = undefined;
                 const path = std.fmt.bufPrint(&buf, "{s}/{s}/{s}{s}", .{ top, sub, name, ext }) catch continue;
-                createFile(base, path);
+                createFile(io, base, path);
                 count += 1;
             }
         }
@@ -196,7 +194,7 @@ const BenchResult = struct {
     zlob_count: usize,
 };
 
-fn benchmarkPattern(pattern_z: [*:0]const u8, iterations: usize) !BenchResult {
+fn benchmarkPattern(io: std.Io, pattern_z: [*:0]const u8, iterations: usize) !BenchResult {
     // Warmup: 3 rounds to populate OS caches and stabilize
     for (0..3) |_| {
         var g: LibcGlobT = undefined;
@@ -224,20 +222,22 @@ fn benchmarkPattern(pattern_z: [*:0]const u8, iterations: usize) !BenchResult {
     }
 
     // Benchmark libc
-    var libc_timer = try Timer.start();
+    const libc_start = std.Io.Timestamp.now(io, .awake);
     for (0..iterations) |_| {
         var g: LibcGlobT = undefined;
         if (glob(pattern_z, 0, null, &g) == 0) globfree(&g);
     }
-    const libc_ns = libc_timer.read();
+    const libc_end = std.Io.Timestamp.now(io, .awake);
+    const libc_ns: u64 = @intCast(libc_start.durationTo(libc_end).nanoseconds);
 
     // Benchmark zlob
-    var zlob_timer = try Timer.start();
+    const zlob_start = std.Io.Timestamp.now(io, .awake);
     for (0..iterations) |_| {
         var z: c_lib.zlob_t = undefined;
         if (c_lib.zlob(pattern_z, 0, null, &z) == 0) c_lib.zlobfree(&z);
     }
-    const zlob_ns = zlob_timer.read();
+    const zlob_end = std.Io.Timestamp.now(io, .awake);
+    const zlob_ns: u64 = @intCast(zlob_start.durationTo(zlob_end).nanoseconds);
 
     return .{
         .libc_ns = libc_ns,
@@ -248,7 +248,7 @@ fn benchmarkPattern(pattern_z: [*:0]const u8, iterations: usize) !BenchResult {
 }
 
 /// Benchmark zlob-only with custom flags (for recursive ** patterns that libc doesn't support)
-fn benchmarkZlobOnly(pattern_z: [*:0]const u8, flags: c_int, iterations: usize) !BenchResult {
+fn benchmarkZlobOnly(io: std.Io, pattern_z: [*:0]const u8, flags: c_int, iterations: usize) !BenchResult {
     // Warmup
     for (0..3) |_| {
         var z: c_lib.zlob_t = undefined;
@@ -266,12 +266,13 @@ fn benchmarkZlobOnly(pattern_z: [*:0]const u8, flags: c_int, iterations: usize) 
     }
 
     // Benchmark zlob
-    var zlob_timer = try Timer.start();
+    const zlob_start = std.Io.Timestamp.now(io, .awake);
     for (0..iterations) |_| {
         var z: c_lib.zlob_t = undefined;
         if (c_lib.zlob(pattern_z, flags, null, &z) == 0) c_lib.zlobfree(&z);
     }
-    const zlob_ns = zlob_timer.read();
+    const zlob_end = std.Io.Timestamp.now(io, .awake);
+    const zlob_ns: u64 = @intCast(zlob_start.durationTo(zlob_end).nanoseconds);
 
     return .{
         .libc_ns = 0,
@@ -314,12 +315,13 @@ fn printZlobOnly(label: []const u8, pattern: []const u8, r: BenchResult, iterati
 }
 
 pub fn main() !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const allocator = std.heap.c_allocator;
     _ = allocator;
 
     // Create temp directory for all test trees
     var tmp_buf: [256]u8 = undefined;
-    const pid = std.os.linux.getpid();
+    const pid = std.c.getpid();
     const tmp_base = std.fmt.bufPrint(&tmp_buf, "/tmp/zlob_bench_{d}", .{pid}) catch unreachable;
 
     var tmp_base_z: [256:0]u8 = undefined;
@@ -327,21 +329,21 @@ pub fn main() !void {
     tmp_base_z[tmp_base.len] = 0;
 
     // Create base and subtree directories
-    const cwd = std.fs.cwd();
-    cwd.makePath(tmp_base) catch |e| {
+    const cwd = std.Io.Dir.cwd();
+    cwd.createDirPath(io, tmp_base) catch |e| {
         std.debug.print("Error creating temp dir: {}\n", .{e});
         return;
     };
 
-    var base_dir = cwd.openDir(tmp_base, .{}) catch |e| {
+    var base_dir = cwd.openDir(io, tmp_base, .{}) catch |e| {
         std.debug.print("Error opening temp dir: {}\n", .{e});
         return;
     };
-    defer base_dir.close();
+    defer base_dir.close(io);
 
     // Cleanup on exit
     defer {
-        cwd.deleteTree(tmp_base) catch {};
+        cwd.deleteTree(io, tmp_base) catch {};
     }
 
     std.debug.print("\n", .{});
@@ -351,15 +353,15 @@ pub fn main() !void {
     // --- Small tree ---
     std.debug.print("--- Small tree (10 files, 3 dirs) ---\n", .{});
     {
-        base_dir.makePath("small") catch {};
-        var small_dir = base_dir.openDir("small", .{}) catch return;
-        defer small_dir.close();
-        buildTree(small_dir, small_tree);
+        base_dir.createDirPath(io, "small") catch {};
+        var small_dir = base_dir.openDir(io, "small", .{}) catch return;
+        defer small_dir.close(io);
+        buildTree(io, small_dir, small_tree);
 
         var path_buf: [512:0]u8 = undefined;
         const prefix = std.fmt.bufPrint(&path_buf, "{s}/small/", .{tmp_base}) catch unreachable;
 
-        posix.chdir(prefix) catch return;
+        std.process.setCurrentPath(io, prefix) catch return;
 
         const small_iters: usize = 10000;
         const patterns = [_][]const u8{ "*.zig", "src/*.zig", "*", "*.md" };
@@ -367,7 +369,7 @@ pub fn main() !void {
             var pat_z: [64:0]u8 = undefined;
             @memcpy(pat_z[0..pat.len], pat);
             pat_z[pat.len] = 0;
-            const r = try benchmarkPattern(&pat_z, small_iters);
+            const r = try benchmarkPattern(io, &pat_z, small_iters);
             printResult("small", pat, r, small_iters);
         }
     }
@@ -375,15 +377,15 @@ pub fn main() !void {
     // --- Medium tree ---
     std.debug.print("\n--- Medium tree (100 files, 20 dirs) ---\n", .{});
     {
-        base_dir.makePath("medium") catch {};
-        var medium_dir = base_dir.openDir("medium", .{}) catch return;
-        defer medium_dir.close();
-        buildTree(medium_dir, medium_tree);
+        base_dir.createDirPath(io, "medium") catch {};
+        var medium_dir = base_dir.openDir(io, "medium", .{}) catch return;
+        defer medium_dir.close(io);
+        buildTree(io, medium_dir, medium_tree);
 
         var path_buf: [512:0]u8 = undefined;
         const prefix = std.fmt.bufPrint(&path_buf, "{s}/medium/", .{tmp_base}) catch unreachable;
 
-        posix.chdir(prefix) catch return;
+        std.process.setCurrentPath(io, prefix) catch return;
 
         const medium_iters: usize = 5000;
         const patterns = [_][]const u8{ "*.zig", "src/*.zig", "src/core/*.zig", "test/*/*.zig", "*" };
@@ -391,7 +393,7 @@ pub fn main() !void {
             var pat_z: [64:0]u8 = undefined;
             @memcpy(pat_z[0..pat.len], pat);
             pat_z[pat.len] = 0;
-            const r = try benchmarkPattern(&pat_z, medium_iters);
+            const r = try benchmarkPattern(io, &pat_z, medium_iters);
             printResult("medium", pat, r, medium_iters);
         }
     }
@@ -399,15 +401,15 @@ pub fn main() !void {
     // --- Large tree ---
     std.debug.print("\n--- Large tree (~5000 files, ~200 dirs) ---\n", .{});
     {
-        base_dir.makePath("large") catch {};
-        var large_dir = base_dir.openDir("large", .{}) catch return;
-        defer large_dir.close();
-        buildLargeTree(large_dir);
+        base_dir.createDirPath(io, "large") catch {};
+        var large_dir = base_dir.openDir(io, "large", .{}) catch return;
+        defer large_dir.close(io);
+        buildLargeTree(io, large_dir);
 
         var path_buf: [512:0]u8 = undefined;
         const prefix = std.fmt.bufPrint(&path_buf, "{s}/large/", .{tmp_base}) catch unreachable;
 
-        posix.chdir(prefix) catch return;
+        std.process.setCurrentPath(io, prefix) catch return;
 
         const large_iters: usize = 1000;
         const patterns = [_][]const u8{ "src/core/*.zig", "src/*/*.zig", "*.zig", "src/core/*.c", "*" };
@@ -415,7 +417,7 @@ pub fn main() !void {
             var pat_z: [64:0]u8 = undefined;
             @memcpy(pat_z[0..pat.len], pat);
             pat_z[pat.len] = 0;
-            const r = try benchmarkPattern(&pat_z, large_iters);
+            const r = try benchmarkPattern(io, &pat_z, large_iters);
             printResult("large", pat, r, large_iters);
         }
     }
@@ -429,7 +431,7 @@ pub fn main() !void {
         {
             var path_buf: [512:0]u8 = undefined;
             const prefix = std.fmt.bufPrint(&path_buf, "{s}/small/", .{tmp_base}) catch unreachable;
-            posix.chdir(prefix) catch return;
+            std.process.setCurrentPath(io, prefix) catch return;
 
             const iters: usize = 10000;
             const rec_patterns = [_][]const u8{ "**/*.zig", "**/*", "**/*.md" };
@@ -437,7 +439,7 @@ pub fn main() !void {
                 var pat_z: [64:0]u8 = undefined;
                 @memcpy(pat_z[0..pat.len], pat);
                 pat_z[pat.len] = 0;
-                const r = try benchmarkZlobOnly(&pat_z, ds_flag, iters);
+                const r = try benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
                 printZlobOnly("small-recursive", pat, r, iters);
             }
         }
@@ -446,7 +448,7 @@ pub fn main() !void {
         {
             var path_buf: [512:0]u8 = undefined;
             const prefix = std.fmt.bufPrint(&path_buf, "{s}/medium/", .{tmp_base}) catch unreachable;
-            posix.chdir(prefix) catch return;
+            std.process.setCurrentPath(io, prefix) catch return;
 
             const iters: usize = 5000;
             const rec_patterns = [_][]const u8{ "**/*.zig", "**/*", "**/*.md" };
@@ -454,7 +456,7 @@ pub fn main() !void {
                 var pat_z: [64:0]u8 = undefined;
                 @memcpy(pat_z[0..pat.len], pat);
                 pat_z[pat.len] = 0;
-                const r = try benchmarkZlobOnly(&pat_z, ds_flag, iters);
+                const r = try benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
                 printZlobOnly("medium-recursive", pat, r, iters);
             }
         }
@@ -463,7 +465,7 @@ pub fn main() !void {
         {
             var path_buf: [512:0]u8 = undefined;
             const prefix = std.fmt.bufPrint(&path_buf, "{s}/large/", .{tmp_base}) catch unreachable;
-            posix.chdir(prefix) catch return;
+            std.process.setCurrentPath(io, prefix) catch return;
 
             const iters: usize = 200;
             const rec_patterns = [_][]const u8{ "**/*.zig", "**/*.c", "**/*" };
@@ -471,7 +473,7 @@ pub fn main() !void {
                 var pat_z: [64:0]u8 = undefined;
                 @memcpy(pat_z[0..pat.len], pat);
                 pat_z[pat.len] = 0;
-                const r = try benchmarkZlobOnly(&pat_z, ds_flag, iters);
+                const r = try benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
                 printZlobOnly("large-recursive", pat, r, iters);
             }
         }

--- a/bench/bench_tree_sizes.zig
+++ b/bench/bench_tree_sizes.zig
@@ -6,10 +6,18 @@ const zlob_flags = @import("zlob_flags");
 extern "c" fn glob(pattern: [*:0]const u8, flags: c_int, errfunc: ?*const anyopaque, pglob: *LibcGlobT) c_int;
 extern "c" fn globfree(pglob: *LibcGlobT) void;
 
+// Must match glibc's full `glob_t` layout so `glob()` does not overwrite
+// adjacent stack slots. See /usr/include/glob.h.
 const LibcGlobT = extern struct {
     pathc: usize,
     pathv: [*c][*c]u8,
     offs: usize,
+    flags: c_int,
+    closedir: ?*const anyopaque,
+    readdir: ?*const anyopaque,
+    opendir: ?*const anyopaque,
+    lstat: ?*const anyopaque,
+    stat: ?*const anyopaque,
 };
 
 // --- Tree creation helpers ---
@@ -194,7 +202,7 @@ const BenchResult = struct {
     zlob_count: usize,
 };
 
-fn benchmarkPattern(io: std.Io, pattern_z: [*:0]const u8, iterations: usize) !BenchResult {
+fn benchmarkPattern(io: std.Io, pattern_z: [*:0]const u8, iterations: usize) BenchResult {
     // Warmup: 3 rounds to populate OS caches and stabilize
     for (0..3) |_| {
         var g: LibcGlobT = undefined;
@@ -248,7 +256,7 @@ fn benchmarkPattern(io: std.Io, pattern_z: [*:0]const u8, iterations: usize) !Be
 }
 
 /// Benchmark zlob-only with custom flags (for recursive ** patterns that libc doesn't support)
-fn benchmarkZlobOnly(io: std.Io, pattern_z: [*:0]const u8, flags: c_int, iterations: usize) !BenchResult {
+fn benchmarkZlobOnly(io: std.Io, pattern_z: [*:0]const u8, flags: c_int, iterations: usize) BenchResult {
     // Warmup
     for (0..3) |_| {
         var z: c_lib.zlob_t = undefined;
@@ -314,7 +322,7 @@ fn printZlobOnly(label: []const u8, pattern: []const u8, r: BenchResult, iterati
     });
 }
 
-pub fn main() !void {
+pub fn main() void {
     const io = std.Io.Threaded.global_single_threaded.io();
     const allocator = std.heap.c_allocator;
     _ = allocator;
@@ -369,7 +377,7 @@ pub fn main() !void {
             var pat_z: [64:0]u8 = undefined;
             @memcpy(pat_z[0..pat.len], pat);
             pat_z[pat.len] = 0;
-            const r = try benchmarkPattern(io, &pat_z, small_iters);
+            const r = benchmarkPattern(io, &pat_z, small_iters);
             printResult("small", pat, r, small_iters);
         }
     }
@@ -393,7 +401,7 @@ pub fn main() !void {
             var pat_z: [64:0]u8 = undefined;
             @memcpy(pat_z[0..pat.len], pat);
             pat_z[pat.len] = 0;
-            const r = try benchmarkPattern(io, &pat_z, medium_iters);
+            const r = benchmarkPattern(io, &pat_z, medium_iters);
             printResult("medium", pat, r, medium_iters);
         }
     }
@@ -417,7 +425,7 @@ pub fn main() !void {
             var pat_z: [64:0]u8 = undefined;
             @memcpy(pat_z[0..pat.len], pat);
             pat_z[pat.len] = 0;
-            const r = try benchmarkPattern(io, &pat_z, large_iters);
+            const r = benchmarkPattern(io, &pat_z, large_iters);
             printResult("large", pat, r, large_iters);
         }
     }
@@ -439,7 +447,7 @@ pub fn main() !void {
                 var pat_z: [64:0]u8 = undefined;
                 @memcpy(pat_z[0..pat.len], pat);
                 pat_z[pat.len] = 0;
-                const r = try benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
+                const r = benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
                 printZlobOnly("small-recursive", pat, r, iters);
             }
         }
@@ -456,7 +464,7 @@ pub fn main() !void {
                 var pat_z: [64:0]u8 = undefined;
                 @memcpy(pat_z[0..pat.len], pat);
                 pat_z[pat.len] = 0;
-                const r = try benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
+                const r = benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
                 printZlobOnly("medium-recursive", pat, r, iters);
             }
         }
@@ -473,7 +481,7 @@ pub fn main() !void {
                 var pat_z: [64:0]u8 = undefined;
                 @memcpy(pat_z[0..pat.len], pat);
                 pat_z[pat.len] = 0;
-                const r = try benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
+                const r = benchmarkZlobOnly(io, &pat_z, ds_flag, iters);
                 printZlobOnly("large-recursive", pat, r, iters);
             }
         }

--- a/bench/benchmark.zig
+++ b/bench/benchmark.zig
@@ -13,6 +13,7 @@ fn naiveFind(haystack: []const u8, needle: u8) ?usize {
 }
 
 pub fn main() !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     std.debug.print("=== SIMD vs Naive Character Search Benchmark ===\n\n", .{});
 
     const test_cases = [_]struct {
@@ -51,15 +52,16 @@ pub fn main() !void {
 
         // Benchmark naive implementation
         {
-            const start = std.time.nanoTimestamp();
+            const start = std.Io.Timestamp.now(io, .awake);
             var result: ?usize = null;
             var i: usize = 0;
             while (i < ITERATIONS) : (i += 1) {
                 result = naiveFind(tc.haystack, tc.needle);
                 std.mem.doNotOptimizeAway(&result); // Prevent optimization
             }
-            const end = std.time.nanoTimestamp();
-            naive_elapsed = @as(f64, @floatFromInt(end - start)) / @as(f64, ITERATIONS);
+            const end = std.Io.Timestamp.now(io, .awake);
+            const elapsed_ns: u64 = @intCast(start.durationTo(end).nanoseconds);
+            naive_elapsed = @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, ITERATIONS);
 
             std.debug.print("  Native:  {d:.2}ns per search", .{naive_elapsed});
             if (result) |pos| {
@@ -71,15 +73,16 @@ pub fn main() !void {
 
         // Benchmark SIMD implementation
         {
-            const start = std.time.nanoTimestamp();
+            const start = std.Io.Timestamp.now(io, .awake);
             var result: ?usize = null;
             var i: usize = 0;
             while (i < ITERATIONS) : (i += 1) {
                 result = zlob.simdFindChar(tc.haystack, tc.needle);
                 std.mem.doNotOptimizeAway(&result); // Prevent optimization
             }
-            const end = std.time.nanoTimestamp();
-            simd_elapsed = @as(f64, @floatFromInt(end - start)) / @as(f64, ITERATIONS);
+            const end = std.Io.Timestamp.now(io, .awake);
+            const elapsed_ns: u64 = @intCast(start.durationTo(end).nanoseconds);
+            simd_elapsed = @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, ITERATIONS);
 
             std.debug.print("  SIMD:   {d:.2}ns per search", .{simd_elapsed});
             if (result) |pos| {

--- a/bench/compare_libc.zig
+++ b/bench/compare_libc.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const c_lib = @import("c_lib");
 
-const Timer = std.time.Timer;
-
 // libc glob types and functions
 extern "c" fn glob(pattern: [*:0]const u8, flags: c_int, errfunc: ?*const anyopaque, pzlob: *GlobT) c_int;
 extern "c" fn globfree(pzlob: *GlobT) void;
@@ -13,9 +11,8 @@ const GlobT = extern struct {
     offs: usize,
 };
 
-fn benchmarkLibcGlob(pattern: [*:0]const u8, iterations: usize) !u64 {
-    var timer = try Timer.start();
-    const start = timer.lap();
+fn benchmarkLibcGlob(io: std.Io, pattern: [*:0]const u8, iterations: usize) !u64 {
+    const start = std.Io.Timestamp.now(io, .awake);
 
     var i: usize = 0;
     while (i < iterations) : (i += 1) {
@@ -26,13 +23,12 @@ fn benchmarkLibcGlob(pattern: [*:0]const u8, iterations: usize) !u64 {
         }
     }
 
-    const end = timer.read();
-    return end - start;
+    const end = std.Io.Timestamp.now(io, .awake);
+    return @intCast(start.durationTo(end).nanoseconds);
 }
 
-fn benchmarkZlobGlob(pattern: [*:0]const u8, iterations: usize) !u64 {
-    var timer = try Timer.start();
-    const start = timer.lap();
+fn benchmarkZlobGlob(io: std.Io, pattern: [*:0]const u8, iterations: usize) !u64 {
+    const start = std.Io.Timestamp.now(io, .awake);
 
     var i: usize = 0;
     while (i < iterations) : (i += 1) {
@@ -43,21 +39,35 @@ fn benchmarkZlobGlob(pattern: [*:0]const u8, iterations: usize) !u64 {
         }
     }
 
-    const end = timer.read();
-    return end - start;
+    const end = std.Io.Timestamp.now(io, .awake);
+    return @intCast(start.durationTo(end).nanoseconds);
 }
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
     // Use C allocator for fair comparison - it's just malloc/free like libc uses
     const allocator = std.heap.c_allocator;
 
-    // Parse command-line arguments
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    // Parse command-line arguments via juicy main's Args iterator
+    var args_iter = try std.process.Args.Iterator.initAllocator(init.minimal.args, init.gpa);
+    defer args_iter.deinit();
+
+    var argv_list: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (argv_list.items) |a| allocator.free(a);
+        argv_list.deinit(allocator);
+    }
+
+    while (args_iter.next()) |arg| {
+        const dup = try allocator.dupe(u8, arg);
+        try argv_list.append(allocator, dup);
+    }
+
+    const args = argv_list.items;
 
     if (args.len != 3) {
-        std.debug.print("Usage: {s} <path> <pattern>\n", .{args[0]});
-        std.debug.print("Example: {s} /home/user/big-repo './**/*.c'\n", .{args[0]});
+        std.debug.print("Usage: {s} <path> <pattern>\n", .{if (args.len > 0) args[0] else "compare_libc"});
+        std.debug.print("Example: {s} /home/user/big-repo './**/*.c'\n", .{if (args.len > 0) args[0] else "compare_libc"});
         std.process.exit(1);
     }
 
@@ -66,7 +76,7 @@ pub fn main() !void {
     const iterations: usize = 1000;
 
     // Change to the specified directory
-    std.posix.chdir(path) catch |err| {
+    std.process.setCurrentPath(io, path) catch |err| {
         std.debug.print("Error: Cannot change to directory '{s}': {}\n", .{ path, err });
         std.process.exit(1);
     };
@@ -100,13 +110,13 @@ pub fn main() !void {
     std.debug.print("Match count: libc={d}, zlob={d}\n\n", .{ libc_count, zlob_count });
 
     // Benchmark libc glob
-    const libc_time = try benchmarkLibcGlob(pattern_z.ptr, iterations);
+    const libc_time = try benchmarkLibcGlob(io, pattern_z.ptr, iterations);
     const libc_avg_ns = libc_time / iterations;
     const libc_avg_us = @as(f64, @floatFromInt(libc_avg_ns)) / 1000.0;
     const libc_total_ms = @as(f64, @floatFromInt(libc_time)) / 1_000_000.0;
 
     // Benchmark zlob glob
-    const zlob_time = try benchmarkZlobGlob(pattern_z.ptr, iterations);
+    const zlob_time = try benchmarkZlobGlob(io, pattern_z.ptr, iterations);
     const zlob_avg_ns = zlob_time / iterations;
     const zlob_avg_us = @as(f64, @floatFromInt(zlob_avg_ns)) / 1000.0;
     const zlob_total_ms = @as(f64, @floatFromInt(zlob_time)) / 1_000_000.0;

--- a/bench/compare_walker.zig
+++ b/bench/compare_walker.zig
@@ -5,12 +5,13 @@ const std = @import("std");
 const walker_mod = @import("walker");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = debug_allocator.deinit();
+    const allocator = debug_allocator.allocator();
 
     // Try to use Linux kernel source as test directory
-    std.process.changeCurDir("/home/neogoose/dev/fff.nvim/big-repo") catch {
+    std.process.setCurrentPath(io, "/home/neogoose/dev/fff.nvim/big-repo") catch {
         std.debug.print("Cannot find big-repo, using current directory\n", .{});
     };
 
@@ -24,36 +25,37 @@ pub fn main() !void {
     };
 
     for (test_cases) |tc| {
-        try runBenchmark(allocator, tc.path, tc.name);
+        try runBenchmark(io, allocator, tc.path, tc.name);
     }
 
     std.debug.print("Benchmark complete.\n", .{});
 }
 
-fn runBenchmark(allocator: std.mem.Allocator, test_path: []const u8, name: []const u8) !void {
+fn runBenchmark(io: std.Io, allocator: std.mem.Allocator, test_path: []const u8, name: []const u8) !void {
     const iterations: usize = 10;
 
     std.debug.print("{s}\n", .{name});
     std.debug.print("{s}\n", .{"-" ** 50});
 
     // Verify directory exists
-    std.fs.cwd().access(test_path, .{}) catch {
+    std.Io.Dir.cwd().access(io, test_path, .{}) catch {
         std.debug.print("  Directory not found, skipping\n\n", .{});
         return;
     };
 
-    // Benchmark std.fs.Dir.walk
+    // Benchmark std.Io.Dir.walk
     var total_std: u64 = 0;
     var count_std: usize = 0;
     for (0..iterations) |_| {
-        var timer = try std.time.Timer.start();
-        var dir = try std.fs.cwd().openDir(test_path, .{ .iterate = true });
-        defer dir.close();
+        const start = std.Io.Timestamp.now(io, .awake);
+        var dir = try std.Io.Dir.cwd().openDir(io, test_path, .{ .iterate = true });
+        defer dir.close(io);
         var w = try dir.walk(allocator);
         defer w.deinit();
         var count: usize = 0;
-        while (try w.next()) |_| count += 1;
-        total_std += timer.read();
+        while (try w.next(io)) |_| count += 1;
+        const end = std.Io.Timestamp.now(io, .awake);
+        total_std += @intCast(start.durationTo(end).nanoseconds);
         count_std = count;
     }
 
@@ -61,12 +63,13 @@ fn runBenchmark(allocator: std.mem.Allocator, test_path: []const u8, name: []con
     var total_optimized: u64 = 0;
     var count_optimized: usize = 0;
     for (0..iterations) |_| {
-        var timer = try std.time.Timer.start();
-        var w = try walker_mod.DefaultWalker.init(allocator, test_path, .{});
+        const start = std.Io.Timestamp.now(io, .awake);
+        var w = try walker_mod.DefaultWalker.init(allocator, io, test_path, .{});
         defer w.deinit();
         var count: usize = 0;
         while (try w.next()) |_| count += 1;
-        total_optimized += timer.read();
+        const end = std.Io.Timestamp.now(io, .awake);
+        total_optimized += @intCast(start.durationTo(end).nanoseconds);
         count_optimized = count;
     }
 

--- a/bench/perf_recursive.zig
+++ b/bench/perf_recursive.zig
@@ -3,7 +3,8 @@ const c_lib = @import("c_lib");
 const zlob_t = c_lib.zlob_t;
 
 pub fn main() !void {
-    std.process.changeCurDir("/home/neogoose/dev/fff.nvim/big-repo") catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    std.process.setCurrentPath(io, "/home/neogoose/dev/fff.nvim/big-repo") catch {};
 
     const pattern = "drivers/**/*.c";
     const iterations = 100;

--- a/bench/perf_test_libc.zig
+++ b/bench/perf_test_libc.zig
@@ -3,13 +3,15 @@ const c_lib = @import("c_lib");
 const zlob_t = c_lib.zlob_t;
 
 pub fn main() !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+
     // Heavy workload for perf profiling
     const iterations = 10000;
 
     std.debug.print("Running {d} iterations on big-repo...\n", .{iterations});
 
     // Change to big repo
-    try std.process.changeCurDir("/home/neogoose/dev/fff.nvim/big-repo");
+    try std.process.setCurrentPath(io, "/home/neogoose/dev/fff.nvim/big-repo");
 
     var i: usize = 0;
     while (i < iterations) : (i += 1) {

--- a/bench/profile_big_repo.zig
+++ b/bench/profile_big_repo.zig
@@ -11,8 +11,10 @@ const TestCase = struct {
 };
 
 pub fn main() !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+
     // Change to big repo
-    try std.process.changeCurDir("/home/neogoose/dev/fff.nvim/big-repo");
+    try std.process.setCurrentPath(io, "/home/neogoose/dev/fff.nvim/big-repo");
     std.debug.print("Changed to big-repo directory\n", .{});
     std.debug.print("Profiling glob.zig implementation\n", .{});
     std.debug.print("========================================\n\n", .{});
@@ -73,8 +75,7 @@ pub fn main() !void {
         }
 
         // Timed run
-        var timer = try std.time.Timer.start();
-        const start = timer.read();
+        const start = std.Io.Timestamp.now(io, .awake);
 
         var i: usize = 0;
         var matches_this_test: usize = 0;
@@ -87,8 +88,8 @@ pub fn main() !void {
             }
         }
 
-        const end = timer.read();
-        const elapsed_ns = end - start;
+        const end = std.Io.Timestamp.now(io, .awake);
+        const elapsed_ns: u64 = @intCast(start.durationTo(end).nanoseconds);
         const avg_ns = elapsed_ns / tc.iterations;
         const avg_us = @as(f64, @floatFromInt(avg_ns)) / 1000.0;
         const avg_ms = avg_us / 1000.0;
@@ -103,7 +104,7 @@ pub fn main() !void {
         std.debug.print("\n", .{});
 
         // Small sleep between tests to let system settle
-        std.Thread.sleep(100 * std.time.ns_per_ms); // 100ms
+        std.Io.sleep(io, std.Io.Duration.fromNanoseconds(100 * std.time.ns_per_ms), .awake) catch {}; // 100ms
     }
 
     std.debug.print("========================================\n", .{});

--- a/bench/test_recursive.zig
+++ b/bench/test_recursive.zig
@@ -3,7 +3,8 @@ const c_lib = @import("c_lib");
 const zlob_t = c_lib.zlob_t;
 
 pub fn main() !void {
-    std.process.changeCurDir("/home/neogoose/dev/fff.nvim/big-repo") catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    std.process.setCurrentPath(io, "/home/neogoose/dev/fff.nvim/big-repo") catch {};
 
     const patterns = [_][:0]const u8{
         "drivers/*/*.c", // Nested (non-recursive)
@@ -18,10 +19,11 @@ pub fn main() !void {
         const iterations = 10;
 
         for (0..iterations) |_| {
-            var timer = try std.time.Timer.start();
+            const start = std.Io.Timestamp.now(io, .awake);
             var result: zlob_t = undefined;
             const ret = c_lib.zlob(pattern, 0, null, &result);
-            total += timer.read();
+            const end = std.Io.Timestamp.now(io, .awake);
+            total += @intCast(start.durationTo(end).nanoseconds);
             if (ret == 0) {
                 count = result.zlo_pathc;
                 c_lib.zlobfree(&result);

--- a/build.zig
+++ b/build.zig
@@ -391,12 +391,12 @@ pub fn build(b: *std.Build) void {
                     .root_source_file = b.path("bench/compare_libc.zig"),
                     .target = target,
                     .optimize = optimize,
+                    .link_libc = true, // for glob()
                     .imports = &.{
                         .{ .name = "c_lib", .module = c_lib_mod },
                     },
                 }),
             });
-            compare_libc.linkLibC(); // Link against libc for glob()
             b.installArtifact(compare_libc);
 
             // libc comparison run step
@@ -418,13 +418,13 @@ pub fn build(b: *std.Build) void {
                     .root_source_file = b.path("bench/perf_test_libc.zig"),
                     .target = target,
                     .optimize = optimize,
+                    .link_libc = true,
                     .imports = &.{
                         .{ .name = "zlob", .module = mod },
                         .{ .name = "c_lib", .module = c_lib_mod },
                     },
                 }),
             });
-            perf_test_libc.linkLibC();
             b.installArtifact(perf_test_libc);
 
             const perf_test_libc_cmd = b.addRunArtifact(perf_test_libc);
@@ -439,6 +439,7 @@ pub fn build(b: *std.Build) void {
                     .root_source_file = b.path("bench/profile_big_repo.zig"),
                     .target = target,
                     .optimize = optimize,
+                    .link_libc = true,
                     .imports = &.{
                         .{ .name = "zlob", .module = mod },
                         .{ .name = "c_lib", .module = c_lib_mod },
@@ -446,7 +447,6 @@ pub fn build(b: *std.Build) void {
                     },
                 }),
             });
-            profile_big_repo.linkLibC();
             b.installArtifact(profile_big_repo);
 
             const profile_big_repo_cmd = b.addRunArtifact(profile_big_repo);
@@ -460,6 +460,7 @@ pub fn build(b: *std.Build) void {
                     .root_source_file = b.path("bench/bench_brace.zig"),
                     .target = target,
                     .optimize = optimize,
+                    .link_libc = true,
                     .imports = &.{
                         .{ .name = "zlob", .module = mod },
                         .{ .name = "c_lib", .module = c_lib_mod },
@@ -467,7 +468,6 @@ pub fn build(b: *std.Build) void {
                     },
                 }),
             });
-            bench_brace.linkLibC();
             b.installArtifact(bench_brace);
 
             const bench_brace_cmd = b.addRunArtifact(bench_brace);
@@ -482,12 +482,12 @@ pub fn build(b: *std.Build) void {
                     .root_source_file = b.path("bench/compare_walker.zig"),
                     .target = target,
                     .optimize = optimize,
+                    .link_libc = true,
                     .imports = &.{
                         .{ .name = "walker", .module = walker_mod },
                     },
                 }),
             });
-            compare_walker.linkLibC();
             b.installArtifact(compare_walker);
 
             const compare_walker_cmd = b.addRunArtifact(compare_walker);
@@ -502,13 +502,13 @@ pub fn build(b: *std.Build) void {
                     .root_source_file = b.path("bench/test_recursive.zig"),
                     .target = target,
                     .optimize = optimize,
+                    .link_libc = true,
                     .imports = &.{
                         .{ .name = "zlob", .module = mod },
                         .{ .name = "c_lib", .module = c_lib_mod },
                     },
                 }),
             });
-            test_recursive.linkLibC();
             b.installArtifact(test_recursive);
 
             const test_recursive_cmd = b.addRunArtifact(test_recursive);
@@ -523,13 +523,13 @@ pub fn build(b: *std.Build) void {
                     .root_source_file = b.path("bench/perf_recursive.zig"),
                     .target = target,
                     .optimize = optimize,
+                    .link_libc = true,
                     .imports = &.{
                         .{ .name = "zlob", .module = mod },
                         .{ .name = "c_lib", .module = c_lib_mod },
                     },
                 }),
             });
-            perf_recursive.linkLibC();
             b.installArtifact(perf_recursive);
         }
 
@@ -541,13 +541,13 @@ pub fn build(b: *std.Build) void {
                     .root_source_file = b.path("bench/bench_tree_sizes.zig"),
                     .target = target,
                     .optimize = .ReleaseFast,
+                    .link_libc = true,
                     .imports = &.{
                         .{ .name = "c_lib", .module = c_lib_mod },
                         .{ .name = "zlob_flags", .module = flags_mod },
                     },
                 }),
             });
-            bench_tree_sizes.linkLibC();
             b.installArtifact(bench_tree_sizes);
 
             const bench_tree_sizes_cmd = b.addRunArtifact(bench_tree_sizes);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0x25d2dabc953631cf, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.

--- a/src/brace_optimizer.zig
+++ b/src/brace_optimizer.zig
@@ -21,7 +21,7 @@ pub fn findClosingBrace(pattern: []const u8, start: usize) ?usize {
 }
 
 pub fn expandBraces(allocator: Allocator, pattern: []const u8) ![][]const u8 {
-    var results = std.ArrayList([]const u8){};
+    var results = std.ArrayList([]const u8).empty;
     errdefer {
         for (results.items) |item| allocator.free(item);
         results.deinit(allocator);
@@ -140,7 +140,7 @@ pub const BracedPattern = struct {
     }
 
     pub fn parse(allocator: Allocator, pattern: []const u8) !BracedPattern {
-        var components = std.ArrayList(BracedComponent){};
+        var components = std.ArrayList(BracedComponent).empty;
         errdefer {
             for (components.items) |comp| {
                 if (comp.pattern_contexts) |contexts| allocator.free(contexts);

--- a/src/c_lib.zig
+++ b/src/c_lib.zig
@@ -15,6 +15,13 @@ const allocator = if (builtin.link_libc)
 else
     std.heap.page_allocator;
 
+/// C callers can't hand us an `Io`, so the C ABI wrappers below use the
+/// stdlib's pre-initialized single-threaded Io. Zig callers should instead
+/// use the `zlob` module directly and pass their own `Io`.
+inline fn cIo() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
 pub const zlob_t = zlob_impl.zlob_t;
 pub const zlob_dirent_t = zlob_impl.zlob_dirent_t;
 pub const DirIterator = zlob_impl.DirIterator;
@@ -31,7 +38,7 @@ pub const zlob_slice_t = extern struct {
 };
 
 pub export fn zlob(pattern: [*:0]const u8, flags: c_int, errfunc: zlob_impl.zlob_errfunc_t, pzlob: *zlob_t) callconv(.c) c_int {
-    if (zlob_impl.glob(allocator, pattern, flags, errfunc, pzlob)) |opt_result| {
+    if (zlob_impl.glob(allocator, cIo(), pattern, flags, errfunc, pzlob)) |opt_result| {
         if (opt_result) |_| {
             return 0; // Success with matches
         } else {
@@ -61,7 +68,7 @@ pub export fn zlob_at(
 ) callconv(.c) c_int {
     const base_slice = mem.sliceTo(base_path, 0);
 
-    if (zlob_impl.globAt(allocator, base_slice, pattern, flags, errfunc, pzlob)) |opt_result| {
+    if (zlob_impl.globAt(allocator, cIo(), base_slice, pattern, flags, errfunc, pzlob)) |opt_result| {
         if (opt_result) |_| {
             return 0; // Success with matches
         } else {

--- a/src/gitignore.zig
+++ b/src/gitignore.zig
@@ -72,20 +72,11 @@ pub const GitIgnore = struct {
 
     /// Load and parse .gitignore from current working directory
     /// Returns null if no .gitignore file exists
-    pub fn loadFromCwd(allocator: Allocator) !?Self {
-        const cwd = std.fs.cwd();
-        const file = cwd.openFile(".gitignore", .{}) catch |err| {
-            if (err == error.FileNotFound) {
-                return null;
-            }
-            return err;
-        };
-        defer file.close();
-
-        const content = file.readToEndAlloc(allocator, 1024 * 1024) catch |err| {
-            if (err == error.StreamTooLong) {
-                return null;
-            }
+    pub fn loadFromCwd(allocator: Allocator, io: std.Io) !?Self {
+        const cwd = std.Io.Dir.cwd();
+        const content = cwd.readFileAlloc(io, ".gitignore", allocator, .limited(1024 * 1024)) catch |err| {
+            if (err == error.FileNotFound) return null;
+            if (err == error.StreamTooLong) return null;
             return err;
         };
 
@@ -94,26 +85,17 @@ pub const GitIgnore = struct {
 
     /// Load and parse .gitignore from a specific directory
     /// Returns null if no .gitignore file exists
-    pub fn loadFromDir(allocator: Allocator, dir_path: []const u8) !?Self {
+    pub fn loadFromDir(allocator: Allocator, io: std.Io, dir_path: []const u8) !?Self {
         var path_buf: [4096]u8 = undefined;
         const gitignore_path = if (dir_path.len > 0 and !mem.eql(u8, dir_path, "."))
             std.fmt.bufPrint(&path_buf, "{s}/.gitignore", .{dir_path}) catch return null
         else
             ".gitignore";
 
-        const cwd = std.fs.cwd();
-        const file = cwd.openFile(gitignore_path, .{}) catch |err| {
-            if (err == error.FileNotFound) {
-                return null;
-            }
-            return err;
-        };
-        defer file.close();
-
-        const content = file.readToEndAlloc(allocator, 1024 * 1024) catch |err| {
-            if (err == error.StreamTooLong) {
-                return null;
-            }
+        const cwd = std.Io.Dir.cwd();
+        const content = cwd.readFileAlloc(io, gitignore_path, allocator, .limited(1024 * 1024)) catch |err| {
+            if (err == error.FileNotFound) return null;
+            if (err == error.StreamTooLong) return null;
             return err;
         };
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -51,11 +51,11 @@ pub fn hasWildcards(s: []const u8) bool {
 ///
 /// You can also pass any integer type build from the ZLOB_* flags if you prefer
 /// or even struct literals like .{ .mark = true } for convenience
-pub fn match(allocator: std.mem.Allocator, pattern: []const u8, flags_param: anytype) !?ZlobResults {
+pub fn match(allocator: std.mem.Allocator, io: std.Io, pattern: []const u8, flags_param: anytype) !?ZlobResults {
     const zflags = flagsToZlobFlags(flags_param);
 
     var pzlob: zlob_t = undefined;
-    const opt_result = try zlob.globSlice(allocator, pattern, zflags.toInt(), null, &pzlob);
+    const opt_result = try zlob.globSlice(allocator, io, pattern, zflags.toInt(), null, &pzlob);
 
     if (opt_result) |_| {
         return ZlobResults{
@@ -168,13 +168,13 @@ pub fn matchPathsAt(allocator: std.mem.Allocator, base_path: []const u8, pattern
 /// ```
 ///
 /// Returns `error.Aborted` if `base_path` is not an absolute path (doesn't start with '/').
-pub fn matchAt(allocator: std.mem.Allocator, base_path: []const u8, pattern: []const u8, flags_param: anytype) !?ZlobResults {
+pub fn matchAt(allocator: std.mem.Allocator, io: std.Io, base_path: []const u8, pattern: []const u8, flags_param: anytype) !?ZlobResults {
     const zflags = flagsToZlobFlags(flags_param);
     const pattern_z = try allocator.dupeZ(u8, pattern);
     defer allocator.free(pattern_z);
 
     var pzlob: zlob_t = undefined;
-    const opt_result = try zlob.globAt(allocator, base_path, pattern_z.ptr, zflags.toInt(), null, &pzlob);
+    const opt_result = try zlob.globAt(allocator, io, base_path, pattern_z.ptr, zflags.toInt(), null, &pzlob);
 
     if (opt_result) |_| {
         return ZlobResults{

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const zlob = @import("zlob");
 const build_options = @import("build_options");
-const fs = std.fs;
 const Io = std.Io;
+const File = std.Io.File;
 
 const version = build_options.version;
 
@@ -25,10 +25,10 @@ const Options = struct {
 };
 
 const BufferedWriter = struct {
-    file_writer: fs.File.Writer,
+    file_writer: File.Writer,
 
-    fn init(file: fs.File, buf: []u8) BufferedWriter {
-        return .{ .file_writer = file.writer(buf) };
+    fn init(io: Io, file: File, buf: []u8) BufferedWriter {
+        return .{ .file_writer = file.writer(io, buf) };
     }
 
     fn writer(self: *BufferedWriter) *Io.Writer {
@@ -39,24 +39,6 @@ const BufferedWriter = struct {
         self.file_writer.interface.flush() catch {};
     }
 };
-
-/// Get stdout file handle cross-platform
-fn getStdOutFile() fs.File {
-    if (builtin.os.tag == .windows) {
-        return fs.File{ .handle = std.os.windows.GetStdHandle(std.os.windows.STD_OUTPUT_HANDLE) catch unreachable };
-    } else {
-        return fs.File{ .handle = std.posix.STDOUT_FILENO };
-    }
-}
-
-/// Get stderr file handle cross-platform
-fn getStdErrFile() fs.File {
-    if (builtin.os.tag == .windows) {
-        return fs.File{ .handle = std.os.windows.GetStdHandle(std.os.windows.STD_ERROR_HANDLE) catch unreachable };
-    } else {
-        return fs.File{ .handle = std.posix.STDERR_FILENO };
-    }
-}
 
 fn printVersion(w: *Io.Writer) void {
     w.print("zlob {s}\n", .{version}) catch {};
@@ -107,14 +89,11 @@ fn printHelp(w: *Io.Writer, program_name: []const u8) void {
     , .{ program_name, program_name, program_name, program_name, program_name, program_name, program_name, program_name }) catch {};
 }
 
-fn parseArgs(allocator: std.mem.Allocator, stderr: *Io.Writer) !Options {
-    var args = try std.process.argsWithAllocator(allocator);
-
+fn parseArgs(args_iter: *std.process.Args.Iterator, stderr: *Io.Writer) !Options {
     var opts = Options{};
-    const program_name = args.next() orelse "zlob";
-    _ = program_name;
+    _ = args_iter.next(); // program name
 
-    while (args.next()) |arg| {
+    while (args_iter.next()) |arg| {
         if (std.mem.startsWith(u8, arg, "-")) {
             if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
                 opts.show_help = true;
@@ -123,7 +102,7 @@ fn parseArgs(allocator: std.mem.Allocator, stderr: *Io.Writer) !Options {
             } else if (std.mem.eql(u8, arg, "-a") or std.mem.eql(u8, arg, "--all")) {
                 opts.show_all = true;
             } else if (std.mem.eql(u8, arg, "-n") or std.mem.eql(u8, arg, "--limit")) {
-                const limit_str = args.next() orelse {
+                const limit_str = args_iter.next() orelse {
                     return error.MissingArgument;
                 };
                 opts.limit = std.fmt.parseInt(usize, limit_str, 10) catch {
@@ -169,25 +148,22 @@ fn parseArgs(allocator: std.mem.Allocator, stderr: *Io.Writer) !Options {
     return opts;
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-
-    var arena = std.heap.ArenaAllocator.init(gpa.allocator());
-    defer arena.deinit();
-    const allocator = arena.allocator();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const allocator = init.arena.allocator();
 
     // Buffered writers for stdout and stderr
     var stdout_buf: [8192]u8 = undefined;
     var stderr_buf: [4096]u8 = undefined;
-    const stdout_file = getStdOutFile();
-    const stderr_file = getStdErrFile();
-    var stdout_writer = BufferedWriter.init(stdout_file, &stdout_buf);
-    var stderr_writer = BufferedWriter.init(stderr_file, &stderr_buf);
+    var stdout_writer = BufferedWriter.init(io, File.stdout(), &stdout_buf);
+    var stderr_writer = BufferedWriter.init(io, File.stderr(), &stderr_buf);
     const stdout = stdout_writer.writer();
     const stderr = stderr_writer.writer();
 
-    const opts = parseArgs(allocator, stderr) catch |err| {
+    var args_iter = try std.process.Args.Iterator.initAllocator(init.minimal.args, init.gpa);
+    defer args_iter.deinit();
+
+    const opts = parseArgs(&args_iter, stderr) catch |err| {
         stderr.print("error: {}\n", .{err}) catch {};
         stderr_writer.flush();
         std.process.exit(1);
@@ -215,7 +191,7 @@ pub fn main() !void {
     if (opts.path) |path| {
         // Combine path and pattern: trim trailing separators (/ on all platforms, \ on Windows)
         const sep_chars = if (builtin.os.tag == .windows) "/\\" else "/";
-        const trimmed_path = std.mem.trimRight(u8, path, sep_chars);
+        const trimmed_path = std.mem.trimEnd(u8, path, sep_chars);
         full_pattern = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ trimmed_path, pattern });
     } else {
         full_pattern = pattern;
@@ -233,7 +209,7 @@ pub fn main() !void {
     flags.nomagic = false; // always enable magic, since we require a pattern argument
     _ = &flags; // suppress unused warning if match accepts anytype
 
-    var match_result = zlob.match(allocator, full_pattern, flags) catch |err| {
+    var match_result = zlob.match(allocator, io, full_pattern, flags) catch |err| {
         stderr.print("error: glob failed: {}\n", .{err}) catch {};
         stderr_writer.flush();
         std.process.exit(1);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -161,28 +161,36 @@ pub fn expandTilde(allocator: Allocator, pattern: [:0]const u8, flags: ZlobFlags
     }
 }
 
+/// Look up an environment variable via libc's `getenv`, returning a borrowed
+/// slice. Returns null if libc is not available, the variable is unset, or
+/// the name cannot be null-terminated.
+fn getEnvVarBorrowed(allocator: Allocator, name: []const u8) ?[]const u8 {
+    if (!builtin.link_libc) return null;
+    const name_z = allocator.dupeZ(u8, name) catch return null;
+    defer allocator.free(name_z);
+    const ptr = std.c.getenv(name_z.ptr) orelse return null;
+    return mem.sliceTo(ptr, 0);
+}
+
 /// Get the current user's home directory.
 /// On Windows, returns an allocated string that must be freed.
 /// On POSIX, returns a borrowed slice from the environment.
 fn getHomeDirectory(allocator: Allocator) ?[]const u8 {
     if (builtin.os.tag == .windows) {
         // On Windows, try USERPROFILE first, then HOMEDRIVE+HOMEPATH
-        if (std.process.getEnvVarOwned(allocator, "USERPROFILE")) |user_profile| {
-            return user_profile;
-        } else |_| {
-            // Try HOMEDRIVE + HOMEPATH
-            const home_drive = std.process.getEnvVarOwned(allocator, "HOMEDRIVE") catch return null;
-            defer allocator.free(home_drive);
-            const home_path = std.process.getEnvVarOwned(allocator, "HOMEPATH") catch return null;
-            defer allocator.free(home_path);
-
-            // Concatenate HOMEDRIVE and HOMEPATH
-            const combined = allocator.alloc(u8, home_drive.len + home_path.len) catch return null;
-            @memcpy(combined[0..home_drive.len], home_drive);
-            @memcpy(combined[home_drive.len..], home_path);
-            return combined;
+        if (getEnvVarBorrowed(allocator, "USERPROFILE")) |user_profile| {
+            return allocator.dupe(u8, user_profile) catch null;
         }
+
+        const home_drive = getEnvVarBorrowed(allocator, "HOMEDRIVE") orelse return null;
+        const home_path = getEnvVarBorrowed(allocator, "HOMEPATH") orelse return null;
+
+        // Concatenate HOMEDRIVE and HOMEPATH
+        const combined = allocator.alloc(u8, home_drive.len + home_path.len) catch return null;
+        @memcpy(combined[0..home_drive.len], home_drive);
+        @memcpy(combined[home_drive.len..], home_path);
+        return combined;
     } else {
-        return std.posix.getenv("HOME");
+        return getEnvVarBorrowed(allocator, "HOME");
     }
 }

--- a/src/walker.zig
+++ b/src/walker.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
+const Io = std.Io;
 // std.posix is not available on Windows
 const posix = if (builtin.os.tag != .windows) std.posix else struct {
     // Stubs for Windows - provide errno values for compatibility
@@ -55,7 +56,7 @@ pub const default_backend: Backend = switch (builtin.os.tag) {
     else => .std_fs,
 };
 
-pub const EntryKind = std.fs.File.Kind;
+pub const EntryKind = std.Io.File.Kind;
 
 pub const Entry = struct {
     /// Path relative to the starting directory
@@ -150,7 +151,7 @@ pub const WalkerConfig = struct {
     dir_filter: ?DirFilter = null,
 
     /// Base directory to start from. If null, path is opened relative to cwd.
-    base_dir: ?std.fs.Dir = null,
+    base_dir: ?std.Io.Dir = null,
 
     /// Error callback for directory open failures.
     /// Called with null-terminated path and errno when a directory cannot be opened.
@@ -243,10 +244,11 @@ const RecursiveGetdents64Walker = struct {
         path_content: [256]u8,
     };
 
-    pub fn init(allocator: Allocator, start_path: []const u8, config: WalkerConfig) !RecursiveGetdents64Walker {
+    pub fn init(allocator: Allocator, io: Io, start_path: []const u8, config: WalkerConfig) !RecursiveGetdents64Walker {
         if (!is_linux) {
             @compileError("Getdents64Walker is only available on Linux");
         }
+        _ = io; // Linux getdents64 backend uses raw syscalls; accepted for API parity with StdFsWalker.
 
         // Use smaller buffer for single-directory iteration (max_depth=0)
         // since we won't be recursing and don't need as much buffering
@@ -255,7 +257,7 @@ const RecursiveGetdents64Walker = struct {
         errdefer allocator.free(buffer);
 
         const dir_stack = std.ArrayList(DirEntry).initCapacity(allocator, 16) catch
-            std.ArrayList(DirEntry){ .items = &.{}, .capacity = 0 };
+            std.ArrayList(DirEntry).empty;
 
         const start_fd = if (config.base_dir) |bd| open: {
             // Use openatZ to open relative to base_dir
@@ -264,7 +266,7 @@ const RecursiveGetdents64Walker = struct {
             @memcpy(path_z[0..start_path.len], start_path);
             path_z[start_path.len] = 0;
 
-            break :open posix.openatZ(bd.fd, &path_z, .{
+            break :open posix.openatZ(bd.handle, &path_z, .{
                 .ACCMODE = .RDONLY,
                 .DIRECTORY = true,
                 .CLOEXEC = true,
@@ -471,14 +473,15 @@ const RecursiveGetdents64Walker = struct {
 
 const StdFsWalker = struct {
     allocator: Allocator,
+    io: Io,
     config: WalkerConfig,
 
     // Stack of directories to process (LIFO order)
     dir_stack: std.ArrayList(StackEntry),
 
     // Current directory being iterated
-    current_dir: ?std.fs.Dir,
-    current_iter: ?std.fs.Dir.Iterator,
+    current_dir: ?std.Io.Dir,
+    current_iter: ?std.Io.Dir.Iterator,
     current_depth: usize,
 
     // Path tracking
@@ -492,7 +495,7 @@ const StdFsWalker = struct {
     finished: bool,
 
     const StackEntry = struct {
-        dir: std.fs.Dir,
+        dir: std.Io.Dir,
         depth: usize,
         path_len: usize,
         // Heap-allocated path prefix to restore when popping
@@ -501,15 +504,15 @@ const StdFsWalker = struct {
         path_prefix: []u8,
     };
 
-    pub fn init(allocator: Allocator, start_path: []const u8, config: WalkerConfig) !StdFsWalker {
-        const root = config.base_dir orelse std.fs.cwd();
-        var dir = root.openDir(start_path, .{ .iterate = true }) catch |err| {
+    pub fn init(allocator: Allocator, io: Io, start_path: []const u8, config: WalkerConfig) !StdFsWalker {
+        const root = config.base_dir orelse std.Io.Dir.cwd();
+        var dir = root.openDir(io, start_path, .{ .iterate = true }) catch |err| {
             try handleOpenErrorStd(start_path, err, config);
             return err;
         };
-        errdefer dir.close();
+        errdefer dir.close(io);
 
-        var dir_stack = std.ArrayList(StackEntry){};
+        var dir_stack = std.ArrayList(StackEntry).empty;
         // Only pre-allocate stack if we're doing recursion
         if (config.max_depth > 0) {
             dir_stack.ensureTotalCapacity(allocator, 64) catch {};
@@ -517,6 +520,7 @@ const StdFsWalker = struct {
 
         return StdFsWalker{
             .allocator = allocator,
+            .io = io,
             .config = config,
             .dir_stack = dir_stack,
             .current_dir = dir,
@@ -548,14 +552,15 @@ const StdFsWalker = struct {
     }
 
     pub fn deinit(self: *StdFsWalker) void {
+        const io = self.io;
         // Close current directory if still open
         if (self.current_dir) |*dir| {
-            dir.close();
+            dir.close(io);
         }
 
         // Close any remaining stacked directories and free path prefixes
         for (self.dir_stack.items) |*entry| {
-            entry.dir.close();
+            entry.dir.close(io);
             if (entry.path_prefix.len > 0) {
                 self.allocator.free(entry.path_prefix);
             }
@@ -565,11 +570,12 @@ const StdFsWalker = struct {
 
     pub fn next(self: *StdFsWalker) !?Entry {
         if (self.finished) return null;
+        const io = self.io;
 
         while (true) {
             // Try to get next entry from current directory
             if (self.current_iter) |*iter| {
-                if (iter.next() catch null) |entry| {
+                if (iter.next(io) catch null) |entry| {
                     // Unified filtering for ".", "..", and hidden files
                     if (shouldSkipEntry(entry.name, self.config.hidden)) continue;
 
@@ -595,11 +601,11 @@ const StdFsWalker = struct {
                             true;
 
                         if (should_descend) {
-                            if (self.current_dir.?.openDir(entry.name, .{ .iterate = true })) |subdir| {
+                            if (self.current_dir.?.openDir(io, entry.name, .{ .iterate = true })) |subdir| {
                                 // Allocate path prefix - only what we need
                                 const path_copy = self.allocator.alloc(u8, self.path_len) catch {
                                     var sd = subdir;
-                                    sd.close();
+                                    sd.close(io);
                                     continue;
                                 };
                                 @memcpy(path_copy, self.path_buffer[0..self.path_len]);
@@ -612,7 +618,7 @@ const StdFsWalker = struct {
                                 }) catch {
                                     self.allocator.free(path_copy);
                                     var sd = subdir;
-                                    sd.close();
+                                    sd.close(io);
                                 };
                             } else |_| {}
                         }
@@ -634,7 +640,7 @@ const StdFsWalker = struct {
 
             // Current directory exhausted - close it and pop from stack
             if (self.current_dir) |*dir| {
-                dir.close();
+                dir.close(io);
                 self.current_dir = null;
                 self.current_iter = null;
             }
@@ -686,7 +692,7 @@ pub const SingleDirIterator = struct {
     /// Open a directory for single-level iteration using raw syscalls.
     /// If base_dir is provided, opens path relative to it; otherwise relative to cwd.
     /// hidden_config controls filtering of ".", "..", and hidden files.
-    pub fn open(path: []const u8, base_dir: ?std.fs.Dir, hidden_config: HiddenConfig) !SingleDirIterator {
+    pub fn open(path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig) !SingleDirIterator {
         if (!is_linux) {
             @compileError("SingleDirIterator.open requires Linux");
         }
@@ -701,7 +707,7 @@ pub const SingleDirIterator = struct {
 
         // Use raw syscall for maximum performance
         const fd: i32 = if (base_dir) |bd| blk: {
-            const rc = linux.openat(bd.fd, &path_z, flags, 0);
+            const rc = linux.openat(bd.handle, &path_z, flags, 0);
             const signed: isize = @bitCast(rc);
             if (signed < 0) return error.AccessDenied;
             break :blk @intCast(rc);
@@ -774,8 +780,9 @@ pub const SingleDirIterator = struct {
 };
 
 pub const StdDirIterator = struct {
-    dir: std.fs.Dir,
-    iter: std.fs.Dir.Iterator,
+    io: Io,
+    dir: std.Io.Dir,
+    iter: std.Io.Dir.Iterator,
     hidden: HiddenConfig,
 
     pub const IterEntry = struct {
@@ -783,10 +790,11 @@ pub const StdDirIterator = struct {
         kind: EntryKind,
     };
 
-    pub fn open(path: []const u8, base_dir: ?std.fs.Dir, hidden_config: HiddenConfig) !StdDirIterator {
-        const root = base_dir orelse std.fs.cwd();
-        var dir = try root.openDir(path, .{ .iterate = true });
+    pub fn open(io: Io, path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig) !StdDirIterator {
+        const root = base_dir orelse std.Io.Dir.cwd();
+        var dir = try root.openDir(io, path, .{ .iterate = true });
         return StdDirIterator{
+            .io = io,
             .dir = dir,
             .iter = dir.iterate(),
             .hidden = hidden_config,
@@ -794,12 +802,12 @@ pub const StdDirIterator = struct {
     }
 
     pub fn close(self: *StdDirIterator) void {
-        self.dir.close();
+        self.dir.close(self.io);
     }
 
     pub fn next(self: *StdDirIterator) ?IterEntry {
         while (true) {
-            const entry = self.iter.next() catch return null;
+            const entry = self.iter.next(self.io) catch return null;
             if (entry) |e| {
                 // Unified filtering for ".", "..", and hidden files
                 if (shouldSkipEntry(e.name, self.hidden)) continue;
@@ -839,16 +847,17 @@ pub const DirIterator = struct {
         }
     };
 
+    io: Io,
     /// Internal state - either real fs, std_fs (for Windows), or ALTDIRFUNC mode
     mode: union(enum) {
         /// Real filesystem using C's opendir/readdir (POSIX only)
         real_fs: struct {
             dir: ?*c.DIR,
         },
-        /// Zig std.fs based iteration (Windows and fallback)
+        /// Zig std.Io based iteration (Windows and fallback)
         std_fs: struct {
-            dir: std.fs.Dir,
-            iter: std.fs.Dir.Iterator,
+            dir: std.Io.Dir,
+            iter: std.Io.Dir.Iterator,
         },
         /// ALTDIRFUNC custom callbacks
         alt_dirfunc: struct {
@@ -900,7 +909,7 @@ pub const DirIterator = struct {
     /// If base_dir is provided, opens path relative to it; otherwise relative to cwd.
     /// hidden_config controls filtering of ".", "..", and hidden files.
     /// fs allows using ALTDIRFUNC callbacks for virtual filesystem support.
-    pub fn openWithProvider(path: []const u8, base_dir: ?std.fs.Dir, hidden_config: HiddenConfig, fs: AltFs) !DirIterator {
+    pub fn openWithProvider(io: Io, path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig, fs: AltFs) !DirIterator {
         if (path.len >= 4096) return error.NameTooLong;
 
         if (fs.isAltDirFunc()) {
@@ -913,6 +922,7 @@ pub const DirIterator = struct {
             if (handle == null) return error.FileNotFound;
 
             return DirIterator{
+                .io = io,
                 .mode = .{ .alt_dirfunc = .{
                     .handle = handle,
                     .readdir = fs.readdir.?,
@@ -923,11 +933,12 @@ pub const DirIterator = struct {
         }
 
         // When base_dir is set (need relative opens) or on Windows or when libc
-        // is not available, use std.fs
+        // is not available, use std.Io
         if (base_dir != null or builtin.os.tag == .windows or !has_libc) {
-            const root = base_dir orelse std.fs.cwd();
-            var dir = try root.openDir(path, .{ .iterate = true });
+            const root = base_dir orelse std.Io.Dir.cwd();
+            var dir = try root.openDir(io, path, .{ .iterate = true });
             return DirIterator{
+                .io = io,
                 .mode = .{ .std_fs = .{
                     .dir = dir,
                     .iter = dir.iterate(),
@@ -951,6 +962,7 @@ pub const DirIterator = struct {
         }
 
         return DirIterator{
+            .io = io,
             .mode = .{ .real_fs = .{ .dir = dir } },
             .hidden = hidden_config,
         };
@@ -959,8 +971,8 @@ pub const DirIterator = struct {
     /// Open a directory for single-level iteration (backward compatible).
     /// If base_dir is provided, opens path relative to it; otherwise relative to cwd.
     /// hidden_config controls filtering of ".", "..", and hidden files.
-    pub fn open(path: []const u8, base_dir: ?std.fs.Dir, hidden_config: HiddenConfig) !DirIterator {
-        return openWithProvider(path, base_dir, hidden_config, AltFs.real_fs);
+    pub fn open(io: Io, path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig) !DirIterator {
+        return openWithProvider(io, path, base_dir, hidden_config, AltFs.real_fs);
     }
 
     /// Configuration for error handling when opening a directory fails.
@@ -973,13 +985,14 @@ pub const DirIterator = struct {
     /// On failure, invokes err_callback (if set) and returns null instead of an error.
     /// Returns error.Aborted only when the callback requests abort or abort_on_error is set.
     pub fn openHandled(
+        io: Io,
         path: []const u8,
-        base_dir: ?std.fs.Dir,
+        base_dir: ?std.Io.Dir,
         hidden_config: HiddenConfig,
         fs: AltFs,
         err_config: OpenErrorConfig,
     ) error{Aborted}!?DirIterator {
-        return openWithProvider(path, base_dir, hidden_config, fs) catch |err| {
+        return openWithProvider(io, path, base_dir, hidden_config, fs) catch |err| {
             if (err_config.err_callback) |cb| {
                 var path_z: [4096:0]u8 = undefined;
                 const len = @min(path.len, 4095);
@@ -1005,7 +1018,7 @@ pub const DirIterator = struct {
                 }
             },
             .std_fs => |*std_mode| {
-                std_mode.dir.close();
+                std_mode.dir.close(self.io);
             },
             .alt_dirfunc => |*alt| {
                 alt.closedir(alt.handle);
@@ -1043,7 +1056,7 @@ pub const DirIterator = struct {
                 return null;
             },
             .std_fs => |*std_mode| {
-                while (std_mode.iter.next() catch null) |entry| {
+                while (std_mode.iter.next(self.io) catch null) |entry| {
                     // Unified filtering for ".", "..", and hidden files
                     if (shouldSkipEntry(entry.name, self.hidden)) continue;
 
@@ -1128,11 +1141,11 @@ test "walker basic" {
     try std.testing.expect(count > 0);
 }
 
-test "EntryKind is std.fs.File.Kind" {
+test "EntryKind is std.Io.File.Kind" {
     // EntryKind is a direct alias — verify the variants we rely on exist
-    try std.testing.expectEqual(EntryKind.file, std.fs.File.Kind.file);
-    try std.testing.expectEqual(EntryKind.directory, std.fs.File.Kind.directory);
-    try std.testing.expectEqual(EntryKind.sym_link, std.fs.File.Kind.sym_link);
+    try std.testing.expectEqual(EntryKind.file, std.Io.File.Kind.file);
+    try std.testing.expectEqual(EntryKind.directory, std.Io.File.Kind.directory);
+    try std.testing.expectEqual(EntryKind.sym_link, std.Io.File.Kind.sym_link);
 }
 
 // ============================================================================

--- a/src/walker.zig
+++ b/src/walker.zig
@@ -3,30 +3,19 @@ const builtin = @import("builtin");
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
 const Io = std.Io;
-// std.posix is not available on Windows
-const posix = if (builtin.os.tag != .windows) std.posix else struct {
-    // Stubs for Windows - provide errno values for compatibility
-    pub const fd_t = std.os.windows.HANDLE;
-    pub const E = enum(c_int) {
-        ACCES = 13,
-        NOENT = 2,
-        NOTDIR = 20,
-        LOOP = 40,
-        NAMETOOLONG = 36,
-        NOMEM = 12,
-        INVAL = 22,
-        IO = 5,
-    };
-    pub fn close(_: anytype) void {}
-    pub fn open(_: anytype, _: anytype, _: anytype) !fd_t {
-        return error.Unsupported;
-    }
-    pub fn openat(_: anytype, _: anytype, _: anytype, _: anytype) !fd_t {
-        return error.Unsupported;
-    }
-    pub fn openatZ(_: anytype, _: anytype, _: anytype, _: anytype) !fd_t {
-        return error.Unsupported;
-    }
+
+/// POSIX errno values used for cross-platform error reporting through the
+/// `ErrCallbackFn` interface. Values are the standard POSIX integers and
+/// match `std.posix.E` on POSIX targets.
+const errno = struct {
+    const ACCES: c_int = 13;
+    const NOENT: c_int = 2;
+    const NOTDIR: c_int = 20;
+    const LOOP: c_int = 40;
+    const NAMETOOLONG: c_int = 36;
+    const NOMEM: c_int = 12;
+    const INVAL: c_int = 22;
+    const IO: c_int = 5;
 };
 
 pub const ErrCallbackFn = *const fn (epath: [*:0]const u8, eerrno: c_int) callconv(.c) c_int;
@@ -188,7 +177,10 @@ inline fn shouldSkipEntry(name: []const u8, hidden: HiddenConfig) bool {
 
 pub fn WalkerType(comptime backend: Backend) type {
     return switch (backend) {
-        .getdents64 => RecursiveGetdents64Walker,
+        .getdents64 => if (builtin.os.tag == .linux)
+            RecursiveGetdents64Walker
+        else
+            @compileError("getdents64 backend is Linux-only"),
         .std_fs => StdFsWalker,
     };
 }
@@ -199,10 +191,11 @@ pub fn isOptimizedBackendAvailable() bool {
     return builtin.os.tag == .linux;
 }
 
-// Uses getdents64 syscall but only for recursive walking
-const RecursiveGetdents64Walker = struct {
-    const is_linux = builtin.os.tag == .linux;
-    const linux = if (is_linux) std.os.linux else undefined;
+// Uses getdents64 syscall but only for recursive walking.
+// Linux-only: the entire body assumes `std.posix` / `std.os.linux` are available.
+const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else struct {
+    const posix = std.posix;
+    const linux = std.os.linux;
 
     const DT_DIR: u8 = 4;
     const DT_REG: u8 = 8;
@@ -245,9 +238,6 @@ const RecursiveGetdents64Walker = struct {
     };
 
     pub fn init(allocator: Allocator, io: Io, start_path: []const u8, config: WalkerConfig) !RecursiveGetdents64Walker {
-        if (!is_linux) {
-            @compileError("Getdents64Walker is only available on Linux");
-        }
         _ = io; // Linux getdents64 backend uses raw syscalls; accepted for API parity with StdFsWalker.
 
         // Use smaller buffer for single-directory iteration (max_depth=0)
@@ -298,8 +288,8 @@ const RecursiveGetdents64Walker = struct {
             @memcpy(path_z[0..len], path[0..len]);
             path_z[len] = 0;
 
-            const errno = zigErrorToPosix(err);
-            if (cb(&path_z, errno) != 0) {
+            const err_code = zigErrorToPosix(err);
+            if (cb(&path_z, err_code) != 0) {
                 return error.Aborted;
             }
         }
@@ -309,8 +299,6 @@ const RecursiveGetdents64Walker = struct {
     }
 
     pub fn deinit(self: *RecursiveGetdents64Walker) void {
-        if (!is_linux) return;
-
         // Close current fd if still open
         if (!self.finished and self.current_fd >= 0) {
             _ = linux.close(self.current_fd);
@@ -329,7 +317,6 @@ const RecursiveGetdents64Walker = struct {
     }
 
     pub fn next(self: *RecursiveGetdents64Walker) !?Entry {
-        if (!is_linux) return null;
         if (self.finished) return null;
 
         while (true) {
@@ -370,8 +357,6 @@ const RecursiveGetdents64Walker = struct {
     }
 
     fn parseNextEntry(self: *RecursiveGetdents64Walker) ?Entry {
-        if (!is_linux) return null;
-
         const base = self.getdents_offset;
         if (base + 19 > self.getdents_len) return null;
 
@@ -530,8 +515,8 @@ const StdFsWalker = struct {
             @memcpy(path_z[0..len], path[0..len]);
             path_z[len] = 0;
 
-            const errno = zigErrorToPosix(err);
-            if (cb(&path_z, errno) != 0) {
+            const err_code = zigErrorToPosix(err);
+            if (cb(&path_z, err_code) != 0) {
                 return error.Aborted;
             }
         }
@@ -1081,14 +1066,14 @@ pub const DirIterator = struct {
 
 fn zigErrorToPosix(err: anyerror) c_int {
     return switch (err) {
-        error.AccessDenied => @intFromEnum(posix.E.ACCES),
-        error.FileNotFound => @intFromEnum(posix.E.NOENT),
-        error.NotDir => @intFromEnum(posix.E.NOTDIR),
-        error.SymLinkLoop => @intFromEnum(posix.E.LOOP),
-        error.NameTooLong => @intFromEnum(posix.E.NAMETOOLONG),
-        error.SystemResources => @intFromEnum(posix.E.NOMEM),
-        error.InvalidHandle, error.InvalidArgument => @intFromEnum(posix.E.INVAL),
-        else => @intFromEnum(posix.E.IO),
+        error.AccessDenied => errno.ACCES,
+        error.FileNotFound => errno.NOENT,
+        error.NotDir => errno.NOTDIR,
+        error.SymLinkLoop => errno.LOOP,
+        error.NameTooLong => errno.NAMETOOLONG,
+        error.SystemResources => errno.NOMEM,
+        error.InvalidHandle, error.InvalidArgument => errno.INVAL,
+        else => errno.IO,
     };
 }
 

--- a/src/walker.zig
+++ b/src/walker.zig
@@ -259,30 +259,19 @@ const RecursiveGetdents64Walker = struct {
         const dir_stack = std.ArrayList(DirEntry).initCapacity(allocator, 16) catch
             std.ArrayList(DirEntry).empty;
 
-        const start_fd = if (config.base_dir) |bd| open: {
-            // Use openatZ to open relative to base_dir
-            var path_z: [4096:0]u8 = undefined;
-            if (start_path.len >= 4096) return error.NameTooLong;
-            @memcpy(path_z[0..start_path.len], start_path);
-            path_z[start_path.len] = 0;
+        var path_z: [4096:0]u8 = undefined;
+        if (start_path.len >= 4096) return error.NameTooLong;
+        @memcpy(path_z[0..start_path.len], start_path);
+        path_z[start_path.len] = 0;
 
-            break :open posix.openatZ(bd.handle, &path_z, .{
-                .ACCMODE = .RDONLY,
-                .DIRECTORY = true,
-                .CLOEXEC = true,
-            }, 0) catch |err| {
-                try handleOpenError(start_path, err, config);
-                return err;
-            };
-        } else open: {
-            break :open posix.open(start_path, .{
-                .ACCMODE = .RDONLY,
-                .DIRECTORY = true,
-                .CLOEXEC = true,
-            }, 0) catch |err| {
-                try handleOpenError(start_path, err, config);
-                return err;
-            };
+        const dir_fd = if (config.base_dir) |bd| bd.handle else posix.AT.FDCWD;
+        const start_fd = posix.openatZ(dir_fd, &path_z, .{
+            .ACCMODE = .RDONLY,
+            .DIRECTORY = true,
+            .CLOEXEC = true,
+        }, 0) catch |err| {
+            try handleOpenError(start_path, err, config);
+            return err;
         };
 
         return RecursiveGetdents64Walker{
@@ -324,12 +313,12 @@ const RecursiveGetdents64Walker = struct {
 
         // Close current fd if still open
         if (!self.finished and self.current_fd >= 0) {
-            posix.close(self.current_fd);
+            _ = linux.close(self.current_fd);
         }
 
         // Close any remaining stacked fds
         for (self.dir_stack.items) |entry| {
-            posix.close(entry.fd);
+            _ = linux.close(entry.fd);
         }
 
         self.dir_stack.deinit(self.allocator);
@@ -356,7 +345,7 @@ const RecursiveGetdents64Walker = struct {
 
             if (@as(isize, @bitCast(bytes_read)) < 0 or bytes_read == 0) {
                 // Current directory exhausted or error - close it and pop next from stack
-                posix.close(self.current_fd);
+                _ = linux.close(self.current_fd);
 
                 // Pop next directory from stack
                 const next_dir = self.dir_stack.pop() orelse {
@@ -451,7 +440,7 @@ const RecursiveGetdents64Walker = struct {
                     @memcpy(entry.path_content[0..copy_len], self.path_buffer[0..copy_len]);
                     self.dir_stack.append(self.allocator, entry) catch {
                         // OOM — close the fd we just opened to avoid leak
-                        posix.close(subdir_fd);
+                        _ = linux.close(subdir_fd);
                     };
                 } else |_| {}
             }

--- a/src/zlob.zig
+++ b/src/zlob.zig
@@ -24,6 +24,7 @@ const c = if (has_libc) std.c else struct {
 };
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
+const Io = std.Io;
 
 const is_windows = builtin.os.tag == .windows;
 
@@ -154,9 +155,9 @@ pub const zlob_t = extern struct {
     }
 };
 
-fn globLiteralPath(allocator: Allocator, path: []const u8, flags: ZlobFlags, pzlob: *zlob_t, base_dir: ?std.fs.Dir) !bool {
-    const root = base_dir orelse std.fs.cwd();
-    const stat = root.statFile(path) catch {
+fn globLiteralPath(allocator: Allocator, path: []const u8, flags: ZlobFlags, pzlob: *zlob_t, io: Io, base_dir: ?std.Io.Dir) !bool {
+    const root = base_dir orelse std.Io.Dir.cwd();
+    const stat = root.statFile(io, path, .{}) catch {
         return false;
     };
 
@@ -556,7 +557,7 @@ inline fn matchWithAlternativesPrecomputedExtglob(name: []const u8, patterns: []
 
 const buildPathInBuffer = utils.buildPathInBuffer;
 
-fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const u8, info: *const PatternInfo, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, directories_only: bool, gitignore_filter: ?*GitIgnore, base_dir: ?std.fs.Dir, fs_provider: walker.AltFs) !?void {
+fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const u8, info: *const PatternInfo, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, directories_only: bool, gitignore_filter: ?*GitIgnore, io: Io, base_dir: ?std.Io.Dir, fs_provider: walker.AltFs) !?void {
     // Note: gitignore filtering is not fully implemented in this path
     // The main recursive and filtered paths handle gitignore
     _ = gitignore_filter;
@@ -602,7 +603,7 @@ fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const 
     else
         ".";
 
-    try expandWildcardComponents(allocator, start_dir, components[0..component_count], 0, &result_paths, directories_only, flags, errfunc, base_dir, fs_provider);
+    try expandWildcardComponents(allocator, start_dir, components[0..component_count], 0, &result_paths, directories_only, flags, errfunc, io, base_dir, fs_provider);
 
     if (result_paths.len() == 0) {
         if (flags.nocheck) {
@@ -639,7 +640,7 @@ fn expandWildcardComponents(
     directories_only: bool,
     flags: ZlobFlags,
     errfunc: zlob_errfunc_t,
-    base_dir: ?std.fs.Dir,
+    io: Io, base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
 ) !void {
     if (component_idx > 65536) {
@@ -673,7 +674,7 @@ fn expandWildcardComponents(
             flags.period,
         );
 
-        var iter = walker.DirIterator.openHandled(current_dir, base_dir, hidden_config, fs_provider, .{
+        var iter = walker.DirIterator.openHandled(io, current_dir, base_dir, hidden_config, fs_provider, .{
             .err_callback = errfunc,
             .abort_on_error = flags.err,
         }) catch return error.Aborted;
@@ -698,7 +699,7 @@ fn expandWildcardComponents(
                 const new_path = buildPathInBuffer(&new_path_buf, current_dir, name);
                 if (new_path.len >= 4096) continue;
 
-                try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, base_dir, fs_provider);
+                try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider);
             }
         }
     } else {
@@ -711,18 +712,18 @@ fn expandWildcardComponents(
         if (!is_final) {
             // For non-final literal components, skip the stat() syscall entirely.
             // Just try to recurse - if the path doesn't exist, the next opendir will fail gracefully.
-            try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, base_dir, fs_provider);
+            try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider);
         } else {
             // For final component, we need stat to check existence and directory-ness
-            const root = base_dir orelse std.fs.cwd();
-            const stat = root.statFile(new_path) catch return;
+            const root = base_dir orelse std.Io.Dir.cwd();
+            const stat = root.statFile(io, new_path, .{}) catch return;
             if (directories_only and stat.kind != .directory) return;
-            try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, base_dir, fs_provider);
+            try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider);
         }
     }
 }
 
-fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?*const brace_optimizer.BracedPattern, flags_in: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, gitignore_filter: ?*GitIgnore, base_dir: ?std.fs.Dir, fs_provider: walker.AltFs) !?void {
+fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?*const brace_optimizer.BracedPattern, flags_in: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, gitignore_filter: ?*GitIgnore, io: Io, base_dir: ?std.Io.Dir, fs_provider: walker.AltFs) !?void {
     var effective_pattern = pattern;
     var flags = flags_in;
 
@@ -746,8 +747,8 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
     if (!hasWildcardsBasic(effective_pattern) and !needs_tilde_expansion and !has_brace_alternatives and !has_extglob_pattern) {
         // Check gitignore for literal path
         if (gitignore_filter) |gi| {
-            const root = base_dir orelse std.fs.cwd();
-            const stat = root.statFile(effective_pattern) catch null;
+            const root = base_dir orelse std.Io.Dir.cwd();
+            const stat = root.statFile(io, effective_pattern, .{}) catch null;
             const is_dir = if (stat) |s| s.kind == .directory else false;
             if (gi.isIgnored(effective_pattern, is_dir)) {
                 if (flags.nocheck) {
@@ -758,7 +759,7 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
         }
 
         // Try to match literal path
-        const found = try globLiteralPath(allocator, effective_pattern, flags, pzlob, base_dir);
+        const found = try globLiteralPath(allocator, effective_pattern, flags, pzlob, io, base_dir);
         if (found) return;
 
         if (flags.nocheck) {
@@ -802,14 +803,14 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
             }
 
             if (has_dir_alternatives or (has_file_alternatives and has_dir_wildcards)) {
-                return globWithBracedComponents(allocator, parsed, &info, flags, errfunc, pzlob, info.directories_only, gitignore_filter, base_dir, fs_provider);
+                return globWithBracedComponents(allocator, parsed, &info, flags, errfunc, pzlob, info.directories_only, gitignore_filter, io, base_dir, fs_provider);
             }
         }
     }
 
     // Fast path: simple pattern with literal prefix (e.g., "src/foo/*.txt")
     if (info.simple_extension != null and info.literal_prefix.len > 0) {
-        return globInSingleDirWithFnmatch(allocator, info.wildcard_suffix, info.literal_prefix, flags, errfunc, pzlob, info.directories_only, gitignore_filter, brace_parsed, base_dir, fs_provider);
+        return globInSingleDirWithFnmatch(allocator, info.wildcard_suffix, info.literal_prefix, flags, errfunc, pzlob, info.directories_only, gitignore_filter, brace_parsed, io, base_dir, fs_provider);
     }
 
     // Only use recursive glob handling if ZLOB_DOUBLESTAR_RECURSIVE is set
@@ -847,7 +848,7 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
                 }
             }
 
-            return globRecursive(allocator, pattern_from_doublestar, dirname, flags, errfunc, pzlob, info.directories_only, brace_parsed, gitignore_filter, base_dir, fs_provider);
+            return globRecursive(allocator, pattern_from_doublestar, dirname, flags, errfunc, pzlob, info.directories_only, brace_parsed, gitignore_filter, io, base_dir, fs_provider);
         }
     }
 
@@ -880,7 +881,7 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
 
     // But skip if pattern has ** (needs special recursive handling)
     if (has_wildcard_in_dir and !info.has_recursive) {
-        return globWithWildcardDirsOptimized(allocator, effective_pattern, &info, flags, errfunc, pzlob, info.directories_only, gitignore_filter, base_dir, fs_provider);
+        return globWithWildcardDirsOptimized(allocator, effective_pattern, &info, flags, errfunc, pzlob, info.directories_only, gitignore_filter, io, base_dir, fs_provider);
     }
 
     var dir_end: usize = 0;
@@ -905,10 +906,10 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
     }
 
     if (flags.doublestar_recursive and info.has_recursive) {
-        return globRecursive(allocator, filename_pattern, dirname, flags, errfunc, pzlob, info.directories_only, brace_parsed, gitignore_filter, base_dir, fs_provider);
+        return globRecursive(allocator, filename_pattern, dirname, flags, errfunc, pzlob, info.directories_only, brace_parsed, gitignore_filter, io, base_dir, fs_provider);
     }
 
-    return globInSingleDirWithFnmatch(allocator, filename_pattern, dirname, flags, errfunc, pzlob, info.directories_only, gitignore_filter, brace_parsed, base_dir, fs_provider);
+    return globInSingleDirWithFnmatch(allocator, filename_pattern, dirname, flags, errfunc, pzlob, info.directories_only, gitignore_filter, brace_parsed, io, base_dir, fs_provider);
 }
 
 fn returnPatternAsResult(allocator: std.mem.Allocator, pattern: []const u8, pzlob: *zlob_t) !?void {
@@ -935,31 +936,31 @@ const expandTilde = utils.expandTilde;
 
 /// Glob within a specific base directory.
 /// base_path must be an absolute path (starts with '/'), otherwise returns error.Aborted.
-pub fn globAt(allocator: std.mem.Allocator, base_path: []const u8, pattern: [*:0]const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t) !?void {
+pub fn globAt(allocator: std.mem.Allocator, io: Io, base_path: []const u8, pattern: [*:0]const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t) !?void {
     // Validate that base_path is absolute
     if (base_path.len == 0 or base_path[0] != '/') {
         return error.Aborted;
     }
 
     // Open the base directory
-    var base_dir = std.fs.openDirAbsolute(base_path, .{ .iterate = true }) catch {
+    var base_dir = std.Io.Dir.openDirAbsolute(io, base_path, .{ .iterate = true }) catch {
         return error.Aborted;
     };
-    defer base_dir.close();
+    defer base_dir.close(io);
 
-    return globInternalZ(allocator, pattern, flags, errfunc, pzlob, base_dir);
+    return globInternalZ(allocator, pattern, flags, errfunc, pzlob, io, base_dir);
 }
 
-pub fn glob(allocator: std.mem.Allocator, pattern: [*:0]const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t) !?void {
-    return globInternalZ(allocator, pattern, flags, errfunc, pzlob, null);
+pub fn glob(allocator: std.mem.Allocator, io: Io, pattern: [*:0]const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t) !?void {
+    return globInternalZ(allocator, pattern, flags, errfunc, pzlob, io, null);
 }
 
-pub fn globSlice(allocator: std.mem.Allocator, pattern: []const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t) !?void {
-    return globInternalSlice(allocator, pattern, flags, errfunc, pzlob, null);
+pub fn globSlice(allocator: std.mem.Allocator, io: Io, pattern: []const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t) !?void {
+    return globInternalSlice(allocator, pattern, flags, errfunc, pzlob, io, null);
 }
 
 /// Internal glob implementation that accepts a slice pattern
-fn globInternalSlice(allocator: std.mem.Allocator, pattern: []const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t, base_dir: ?std.fs.Dir) !?void {
+fn globInternalSlice(allocator: std.mem.Allocator, pattern: []const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t, io: Io, base_dir: ?std.Io.Dir) !?void {
     const gf = ZlobFlags.fromInt(flags);
     if (!gf.append) {
         pzlob.zlo_pathc = 0;
@@ -1008,7 +1009,7 @@ fn globInternalSlice(allocator: std.mem.Allocator, pattern: []const u8, flags: c
     defer if (gitignore_instance) |*gi| gi.deinit();
 
     if (gf.gitignore) {
-        gitignore_instance = GitIgnore.loadFromCwd(allocator) catch null;
+        gitignore_instance = GitIgnore.loadFromCwd(allocator, io) catch null;
     }
     const gitignore_ptr: ?*GitIgnore = if (gitignore_instance) |*gi| gi else null;
 
@@ -1016,7 +1017,7 @@ fn globInternalSlice(allocator: std.mem.Allocator, pattern: []const u8, flags: c
     const result = blk: {
         if (gf.brace and brace_optimizer.containsBraces(pattern_slice)) {
             var opt = brace_optimizer.analyzeBracedPattern(allocator, pattern_slice) catch {
-                break :blk try globBraceExpand(allocator, pattern_slice, gf, errfunc, pzlob, gitignore_ptr, base_dir, fs_provider);
+                break :blk try globBraceExpand(allocator, pattern_slice, gf, errfunc, pzlob, gitignore_ptr, io, base_dir, fs_provider);
             };
             defer opt.deinit();
 
@@ -1030,20 +1031,21 @@ fn globInternalSlice(allocator: std.mem.Allocator, pattern: []const u8, flags: c
                         errfunc,
                         pzlob,
                         gitignore_ptr,
+                        io,
                         base_dir,
                         fs_provider,
                     );
                 },
                 .fallback => {
-                    break :blk try globBraceExpand(allocator, pattern_slice, gf, errfunc, pzlob, gitignore_ptr, base_dir, fs_provider);
+                    break :blk try globBraceExpand(allocator, pattern_slice, gf, errfunc, pzlob, gitignore_ptr, io, base_dir, fs_provider);
                 },
                 .no_braces => {
-                    break :blk try globBraceExpand(allocator, pattern_slice, gf, errfunc, pzlob, gitignore_ptr, base_dir, fs_provider);
+                    break :blk try globBraceExpand(allocator, pattern_slice, gf, errfunc, pzlob, gitignore_ptr, io, base_dir, fs_provider);
                 },
             }
         }
 
-        break :blk try globSingle(allocator, pattern_slice, null, gf, errfunc, pzlob, gitignore_ptr, base_dir, fs_provider);
+        break :blk try globSingle(allocator, pattern_slice, null, gf, errfunc, pzlob, gitignore_ptr, io, base_dir, fs_provider);
     };
 
     if (has_magic) {
@@ -1060,11 +1062,11 @@ fn globInternalSlice(allocator: std.mem.Allocator, pattern: []const u8, flags: c
     return result;
 }
 
-fn globInternalZ(allocator: std.mem.Allocator, pattern: [*:0]const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t, base_dir: ?std.fs.Dir) !?void {
-    return globInternalSlice(allocator, mem.sliceTo(pattern, 0), flags, errfunc, pzlob, base_dir);
+fn globInternalZ(allocator: std.mem.Allocator, pattern: [*:0]const u8, flags: c_int, errfunc: zlob_errfunc_t, pzlob: *zlob_t, io: Io, base_dir: ?std.Io.Dir) !?void {
+    return globInternalSlice(allocator, mem.sliceTo(pattern, 0), flags, errfunc, pzlob, io, base_dir);
 }
 
-fn globBraceExpand(allocator: std.mem.Allocator, pattern: []const u8, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, gitignore_filter: ?*GitIgnore, base_dir: ?std.fs.Dir, fs_provider: walker.AltFs) !?void {
+fn globBraceExpand(allocator: std.mem.Allocator, pattern: []const u8, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, gitignore_filter: ?*GitIgnore, io: Io, base_dir: ?std.Io.Dir, fs_provider: walker.AltFs) !?void {
     // Use brace_optimizer.expandBraces for consistent nested brace handling
     const expanded = try brace_optimizer.expandBraces(allocator, pattern);
     defer {
@@ -1087,7 +1089,7 @@ fn globBraceExpand(allocator: std.mem.Allocator, pattern: []const u8, flags: Zlo
         temp_pzlob.zlo_pathv = null;
         temp_pzlob.zlo_offs = 0;
 
-        _ = try globSingle(allocator, exp_slice, null, flags.without(.{ .append = true }), errfunc, &temp_pzlob, gitignore_filter, base_dir, fs_provider);
+        _ = try globSingle(allocator, exp_slice, null, flags.without(.{ .append = true }), errfunc, &temp_pzlob, gitignore_filter, io, base_dir, fs_provider);
 
         // Collect results from temp_pzlob
         if (temp_pzlob.zlo_pathc > 0) {
@@ -1195,11 +1197,11 @@ inline fn matchWithAlternativesPrecomputed(name: []const u8, contexts: []const P
     return false;
 }
 
-fn globRecursive(allocator: std.mem.Allocator, pattern: []const u8, dirname: []const u8, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, directories_only: bool, brace_parsed: ?*const brace_optimizer.BracedPattern, gitignore_filter: ?*GitIgnore, base_dir: ?std.fs.Dir, fs_provider: walker.AltFs) !?void {
+fn globRecursive(allocator: std.mem.Allocator, pattern: []const u8, dirname: []const u8, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, directories_only: bool, brace_parsed: ?*const brace_optimizer.BracedPattern, gitignore_filter: ?*GitIgnore, io: Io, base_dir: ?std.Io.Dir, fs_provider: walker.AltFs) !?void {
     const info = analyzePattern(pattern, flags);
 
     // Split pattern at **
-    const double_star_pos = mem.indexOf(u8, pattern, "**") orelse return globInSingleDirWithFnmatch(allocator, pattern, dirname, flags, errfunc, pzlob, directories_only, gitignore_filter, brace_parsed, base_dir, fs_provider);
+    const double_star_pos = mem.indexOf(u8, pattern, "**") orelse return globInSingleDirWithFnmatch(allocator, pattern, dirname, flags, errfunc, pzlob, directories_only, gitignore_filter, brace_parsed, io, base_dir, fs_provider);
 
     var after_double_star = pattern[double_star_pos + 2 ..];
 
@@ -1381,12 +1383,13 @@ fn globRecursive(allocator: std.mem.Allocator, pattern: []const u8, dirname: []c
             &all_results,
             &info,
             errfunc,
+            io,
             base_dir,
             fs_provider,
         );
     } else {
         // Use unified walker for both simple (**/*.txt) and complex (**/foo/*.txt) patterns
-        try globRecursiveWalk(allocator, &rec_pattern, start_dir, flags, &all_results, &info, errfunc, base_dir, fs_provider);
+        try globRecursiveWalk(allocator, &rec_pattern, start_dir, flags, &all_results, &info, errfunc, io, base_dir, fs_provider);
     }
 
     if (all_results.len() == 0) {
@@ -1409,7 +1412,7 @@ fn globWithBracedComponents(
     pzlob: *zlob_t,
     directories_only: bool,
     gitignore_filter: ?*GitIgnore,
-    base_dir: ?std.fs.Dir,
+    io: Io, base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
 ) !?void {
     _ = gitignore_filter; // TODO: Apply gitignore filtering
@@ -1471,8 +1474,8 @@ fn globWithBracedComponents(
     // If there are no wildcard/brace components left, just check if the path exists
     if (start_component_idx >= parsed.components.len) {
         // No wildcard components - just verify path exists and add it
-        const root = base_dir orelse std.fs.cwd();
-        _ = root.statFile(start_dir) catch return null;
+        const root = base_dir orelse std.Io.Dir.cwd();
+        _ = root.statFile(io, start_dir, .{}) catch return null;
         const path_copy = try allocator.allocSentinel(u8, start_dir.len, 0);
         @memcpy(path_copy[0..start_dir.len], start_dir);
         try all_results.append(@ptrCast(path_copy.ptr), start_dir.len);
@@ -1496,6 +1499,7 @@ fn globWithBracedComponents(
         &all_results,
         directories_only,
         errfunc,
+        io,
         base_dir,
         fs_provider,
         struct {
@@ -1571,7 +1575,7 @@ fn walkBracedComponents(
     results: *ResultsList,
     directories_only: bool,
     errfunc: zlob_errfunc_t,
-    base_dir: ?std.fs.Dir,
+    io: Io, base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
     comptime onComplete: fn (std.mem.Allocator, []const u8, *ResultsList, bool) error{ OutOfMemory, Aborted }!void,
 ) error{ OutOfMemory, Aborted }!void {
@@ -1592,7 +1596,7 @@ fn walkBracedComponents(
     };
 
     // Use walker's DirIterator with FsProvider for ALTDIRFUNC support
-    var iter = walker.DirIterator.openHandled(current_dir, base_dir, hidden_config, fs_provider, .{
+    var iter = walker.DirIterator.openHandled(io, current_dir, base_dir, hidden_config, fs_provider, .{
         .err_callback = errfunc,
         .abort_on_error = flags.err,
     }) catch return error.Aborted;
@@ -1619,6 +1623,7 @@ fn walkBracedComponents(
                 results,
                 directories_only,
                 errfunc,
+                io,
                 base_dir,
                 fs_provider,
                 onComplete,
@@ -1638,13 +1643,13 @@ fn globRecursiveWithBracedPrefix(
     results: *ResultsList,
     info: *const PatternInfo,
     errfunc: zlob_errfunc_t,
-    base_dir: ?std.fs.Dir,
+    io: Io, base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
 ) !void {
     // If we've matched all pre-doublestar components, start the recursive walk
     if (component_idx >= pre_ds_components.len) {
         // Use unified walker for both simple and complex patterns
-        try globRecursiveWalk(allocator, rec_pattern, current_dir, flags, results, info, errfunc, base_dir, fs_provider);
+        try globRecursiveWalk(allocator, rec_pattern, current_dir, flags, results, info, errfunc, io, base_dir, fs_provider);
         return;
     }
 
@@ -1663,7 +1668,7 @@ fn globRecursiveWithBracedPrefix(
     };
 
     // Use walker's DirIterator with FsProvider for ALTDIRFUNC support
-    var iter = walker.DirIterator.openHandled(current_dir, base_dir, hidden_config, fs_provider, .{
+    var iter = walker.DirIterator.openHandled(io, current_dir, base_dir, hidden_config, fs_provider, .{
         .err_callback = errfunc,
         .abort_on_error = flags.err,
     }) catch return error.Aborted;
@@ -1690,6 +1695,7 @@ fn globRecursiveWithBracedPrefix(
                 results,
                 info,
                 errfunc,
+                io,
                 base_dir,
                 fs_provider,
             );
@@ -1779,7 +1785,7 @@ fn globRecursiveWalk(
     results: *ResultsList,
     info: *const PatternInfo,
     errfunc: zlob_errfunc_t,
-    base_dir: ?std.fs.Dir,
+    io: Io, base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
 ) !void {
     const has_dir_components = rec_pattern.dir_components.len > 0;
@@ -1835,7 +1841,7 @@ fn globRecursiveWalk(
         };
     }
 
-    var dir_walker = walker.DefaultWalker.init(allocator, start_dir, walker_config) catch |err| {
+    var dir_walker = walker.DefaultWalker.init(allocator, io, start_dir, walker_config) catch |err| {
         return if (err == error.Aborted) error.Aborted else {};
     };
     defer dir_walker.deinit();
@@ -1970,7 +1976,7 @@ fn matchDirComponents(
 pub const PathBuildResult = utils.PathBuildResult;
 const buildFullPathWithMark = utils.buildFullPathWithMark;
 
-fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8, dirname: []const u8, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, directories_only: bool, gitignore_filter: ?*GitIgnore, brace_parsed: ?*const brace_optimizer.BracedPattern, base_dir: ?std.fs.Dir, fs_provider: walker.AltFs) !?void {
+fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8, dirname: []const u8, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, directories_only: bool, gitignore_filter: ?*GitIgnore, brace_parsed: ?*const brace_optimizer.BracedPattern, io: Io, base_dir: ?std.Io.Dir, fs_provider: walker.AltFs) !?void {
     // If we have brace alternatives for the filename pattern, use them for matching
     // e.g., "*.{toml,lock}" -> alternatives = ["*.toml", "*.lock"]
     const file_alternatives: ?[]const PatternContext = if (brace_parsed) |bp| blk: {
@@ -2010,7 +2016,7 @@ fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8,
     );
 
     // Use walker's DirIterator with FsProvider for ALTDIRFUNC support
-    var iter = walker.DirIterator.openHandled(dirname, base_dir, hidden_config, fs_provider, .{
+    var iter = walker.DirIterator.openHandled(io, dirname, base_dir, hidden_config, fs_provider, .{
         .err_callback = errfunc,
         .abort_on_error = flags.err,
     }) catch return error.Aborted;

--- a/src/zlob.zig
+++ b/src/zlob.zig
@@ -640,7 +640,8 @@ fn expandWildcardComponents(
     directories_only: bool,
     flags: ZlobFlags,
     errfunc: zlob_errfunc_t,
-    io: Io, base_dir: ?std.Io.Dir,
+    io: Io,
+    base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
 ) !void {
     if (component_idx > 65536) {
@@ -1412,7 +1413,8 @@ fn globWithBracedComponents(
     pzlob: *zlob_t,
     directories_only: bool,
     gitignore_filter: ?*GitIgnore,
-    io: Io, base_dir: ?std.Io.Dir,
+    io: Io,
+    base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
 ) !?void {
     _ = gitignore_filter; // TODO: Apply gitignore filtering
@@ -1575,7 +1577,8 @@ fn walkBracedComponents(
     results: *ResultsList,
     directories_only: bool,
     errfunc: zlob_errfunc_t,
-    io: Io, base_dir: ?std.Io.Dir,
+    io: Io,
+    base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
     comptime onComplete: fn (std.mem.Allocator, []const u8, *ResultsList, bool) error{ OutOfMemory, Aborted }!void,
 ) error{ OutOfMemory, Aborted }!void {
@@ -1643,7 +1646,8 @@ fn globRecursiveWithBracedPrefix(
     results: *ResultsList,
     info: *const PatternInfo,
     errfunc: zlob_errfunc_t,
-    io: Io, base_dir: ?std.Io.Dir,
+    io: Io,
+    base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
 ) !void {
     // If we've matched all pre-doublestar components, start the recursive walk
@@ -1785,7 +1789,8 @@ fn globRecursiveWalk(
     results: *ResultsList,
     info: *const PatternInfo,
     errfunc: zlob_errfunc_t,
-    io: Io, base_dir: ?std.Io.Dir,
+    io: Io,
+    base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
 ) !void {
     const has_dir_components = rec_pattern.dir_components.len > 0;

--- a/test/test_append.zig
+++ b/test/test_append.zig
@@ -5,17 +5,18 @@ const zlob_flags = @import("zlob_flags");
 
 test "ZLOB_APPEND - basic append two patterns" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    try std.fs.cwd().makePath("test_append_basic");
-    defer std.fs.cwd().deleteTree("test_append_basic") catch {};
-    var test_dir = try std.fs.cwd().openDir("test_append_basic", .{});
-    defer test_dir.close();
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_basic");
+    defer std.Io.Dir.cwd().deleteTree(io, "test_append_basic") catch {};
+    var test_dir = try std.Io.Dir.cwd().openDir(io, "test_append_basic", .{});
+    defer test_dir.close(io);
 
     // Create test files
-    try test_dir.writeFile(.{ .sub_path = "file1.txt", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "file2.txt", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "file3.log", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "file4.log", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "file1.txt", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "file2.txt", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "file3.log", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "file4.log", .data = "" });
 
     var pzlob: c_lib.zlob_t = undefined;
 
@@ -57,16 +58,17 @@ test "ZLOB_APPEND - basic append two patterns" {
 
 test "ZLOB_APPEND - three consecutive appends" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    try std.fs.cwd().makePath("test_append_three");
-    defer std.fs.cwd().deleteTree("test_append_three") catch {};
-    var test_dir = try std.fs.cwd().openDir("test_append_three", .{});
-    defer test_dir.close();
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_three");
+    defer std.Io.Dir.cwd().deleteTree(io, "test_append_three") catch {};
+    var test_dir = try std.Io.Dir.cwd().openDir(io, "test_append_three", .{});
+    defer test_dir.close(io);
 
     // Create test files
-    try test_dir.writeFile(.{ .sub_path = "a.c", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "b.h", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "c.zig", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "a.c", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "b.h", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "c.zig", .data = "" });
 
     var pzlob: c_lib.zlob_t = undefined;
 
@@ -93,13 +95,14 @@ test "ZLOB_APPEND - three consecutive appends" {
 
 test "ZLOB_APPEND - append to empty results" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    try std.fs.cwd().makePath("test_append_empty");
-    defer std.fs.cwd().deleteTree("test_append_empty") catch {};
-    var test_dir = try std.fs.cwd().openDir("test_append_empty", .{});
-    defer test_dir.close();
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_empty");
+    defer std.Io.Dir.cwd().deleteTree(io, "test_append_empty") catch {};
+    var test_dir = try std.Io.Dir.cwd().openDir(io, "test_append_empty", .{});
+    defer test_dir.close(io);
 
-    try test_dir.writeFile(.{ .sub_path = "file.txt", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "file.txt", .data = "" });
 
     var pzlob: c_lib.zlob_t = undefined;
 
@@ -121,16 +124,17 @@ test "ZLOB_APPEND - append to empty results" {
 
 test "ZLOB_APPEND - preserve order with sorting" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    try std.fs.cwd().makePath("test_append_order");
-    defer std.fs.cwd().deleteTree("test_append_order") catch {};
-    var test_dir = try std.fs.cwd().openDir("test_append_order", .{});
-    defer test_dir.close();
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_order");
+    defer std.Io.Dir.cwd().deleteTree(io, "test_append_order") catch {};
+    var test_dir = try std.Io.Dir.cwd().openDir(io, "test_append_order", .{});
+    defer test_dir.close(io);
 
-    try test_dir.writeFile(.{ .sub_path = "z.txt", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "a.txt", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "m.log", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "b.log", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "z.txt", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "a.txt", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "m.log", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "b.log", .data = "" });
 
     var pzlob: c_lib.zlob_t = undefined;
 
@@ -163,21 +167,22 @@ test "ZLOB_APPEND - preserve order with sorting" {
 
 test "ZLOB_APPEND - with subdirectories" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    try std.fs.cwd().makePath("test_append_dirs/dir1");
-    try std.fs.cwd().makePath("test_append_dirs/dir2");
-    defer std.fs.cwd().deleteTree("test_append_dirs") catch {};
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_dirs/dir1");
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_dirs/dir2");
+    defer std.Io.Dir.cwd().deleteTree(io, "test_append_dirs") catch {};
 
-    var test_dir = try std.fs.cwd().openDir("test_append_dirs", .{});
-    defer test_dir.close();
+    var test_dir = try std.Io.Dir.cwd().openDir(io, "test_append_dirs", .{});
+    defer test_dir.close(io);
 
-    var dir1 = try test_dir.openDir("dir1", .{});
-    defer dir1.close();
-    var dir2 = try test_dir.openDir("dir2", .{});
-    defer dir2.close();
+    var dir1 = try test_dir.openDir(io, "dir1", .{});
+    defer dir1.close(io);
+    var dir2 = try test_dir.openDir(io, "dir2", .{});
+    defer dir2.close(io);
 
-    try dir1.writeFile(.{ .sub_path = "file.txt", .data = "" });
-    try dir2.writeFile(.{ .sub_path = "file.txt", .data = "" });
+    try dir1.writeFile(io, .{ .sub_path = "file.txt", .data = "" });
+    try dir2.writeFile(io, .{ .sub_path = "file.txt", .data = "" });
 
     var pzlob: c_lib.zlob_t = undefined;
 
@@ -198,23 +203,24 @@ test "ZLOB_APPEND - with subdirectories" {
 
 test "ZLOB_APPEND - append many results" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    try std.fs.cwd().makePath("test_append_many");
-    defer std.fs.cwd().deleteTree("test_append_many") catch {};
-    var test_dir = try std.fs.cwd().openDir("test_append_many", .{});
-    defer test_dir.close();
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_many");
+    defer std.Io.Dir.cwd().deleteTree(io, "test_append_many") catch {};
+    var test_dir = try std.Io.Dir.cwd().openDir(io, "test_append_many", .{});
+    defer test_dir.close(io);
 
     // Create many files
     for (0..50) |i| {
         const name = try std.fmt.allocPrint(allocator, "file{d}.txt", .{i});
         defer allocator.free(name);
-        try test_dir.writeFile(.{ .sub_path = name, .data = "" });
+        try test_dir.writeFile(io, .{ .sub_path = name, .data = "" });
     }
 
     for (0..50) |i| {
         const name = try std.fmt.allocPrint(allocator, "data{d}.log", .{i});
         defer allocator.free(name);
-        try test_dir.writeFile(.{ .sub_path = name, .data = "" });
+        try test_dir.writeFile(io, .{ .sub_path = name, .data = "" });
     }
 
     var pzlob: c_lib.zlob_t = undefined;
@@ -236,13 +242,14 @@ test "ZLOB_APPEND - append many results" {
 
 test "ZLOB_APPEND - without initial glob should work" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    try std.fs.cwd().makePath("test_append_first");
-    defer std.fs.cwd().deleteTree("test_append_first") catch {};
-    var test_dir = try std.fs.cwd().openDir("test_append_first", .{});
-    defer test_dir.close();
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_first");
+    defer std.Io.Dir.cwd().deleteTree(io, "test_append_first") catch {};
+    var test_dir = try std.Io.Dir.cwd().openDir(io, "test_append_first", .{});
+    defer test_dir.close(io);
 
-    try test_dir.writeFile(.{ .sub_path = "file.txt", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "file.txt", .data = "" });
 
     var pzlob: c_lib.zlob_t = undefined;
     pzlob.zlo_pathc = 0;
@@ -263,15 +270,16 @@ test "ZLOB_APPEND - without initial glob should work" {
 
 test "ZLOB_APPEND - combined with ZLOB_NOSORT" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    try std.fs.cwd().makePath("test_append_nosort");
-    defer std.fs.cwd().deleteTree("test_append_nosort") catch {};
-    var test_dir = try std.fs.cwd().openDir("test_append_nosort", .{});
-    defer test_dir.close();
+    try std.Io.Dir.cwd().createDirPath(io, "test_append_nosort");
+    defer std.Io.Dir.cwd().deleteTree(io, "test_append_nosort") catch {};
+    var test_dir = try std.Io.Dir.cwd().openDir(io, "test_append_nosort", .{});
+    defer test_dir.close(io);
 
-    try test_dir.writeFile(.{ .sub_path = "z.txt", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "a.txt", .data = "" });
-    try test_dir.writeFile(.{ .sub_path = "m.log", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "z.txt", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "a.txt", .data = "" });
+    try test_dir.writeFile(io, .{ .sub_path = "m.log", .data = "" });
 
     var pzlob: c_lib.zlob_t = undefined;
 

--- a/test/test_brace.zig
+++ b/test/test_brace.zig
@@ -397,23 +397,25 @@ fn createBraceTestFiles(allocator: std.mem.Allocator, base_path: []const u8) !vo
         _ = c.mkdir(&path_z, 0o755);
     }
 
+    const io = std.Io.Threaded.global_single_threaded.io();
+
     // Create files
     for (files) |file| {
         const full_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ base_path, file });
         defer allocator.free(full_path);
 
-        const f = std.fs.cwd().createFile(full_path, .{}) catch continue;
-        defer f.close();
-        _ = f.write("test content\n") catch {};
+        var f = std.Io.Dir.cwd().createFile(io, full_path, .{}) catch continue;
+        defer f.close(io);
+        _ = f.writeStreamingAll(io, "test content\n") catch {};
     }
 }
 
 fn cleanupBraceTestFiles(allocator: std.mem.Allocator, base_path: []const u8) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const full_path_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{base_path});
     defer allocator.free(full_path_str);
 
-    const result = std.process.Child.run(.{
-        .allocator = allocator,
+    const result = std.process.run(allocator, io, .{
         .argv = &[_][]const u8{ "rm", "-rf", full_path_str },
     }) catch return;
     allocator.free(result.stdout);
@@ -421,10 +423,11 @@ fn cleanupBraceTestFiles(allocator: std.mem.Allocator, base_path: []const u8) !v
 }
 
 /// Helper to change to test directory and restore on defer
-fn withTestDir(allocator: std.mem.Allocator, base_path: []const u8, cwd_buf: *[4096]u8) ![]const u8 {
+fn withTestDir(allocator: std.mem.Allocator, base_path: []const u8) ![]const u8 {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{base_path});
-    const old_cwd = try std.posix.getcwd(cwd_buf);
-    try std.posix.chdir(test_dir_str);
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    try std.process.setCurrentPath(io, test_dir_str);
     return old_cwd;
 }
 
@@ -477,10 +480,11 @@ test "ZLOB_BRACE filesystem - simple extension alternatives" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.{toml,lock}");
     defer allocator.free(pattern);
@@ -505,10 +509,11 @@ test "ZLOB_BRACE filesystem - wildcard with extension alternatives" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "config.{yaml,yml}");
     defer allocator.free(pattern);
@@ -533,10 +538,11 @@ test "ZLOB_BRACE filesystem - directory alternatives" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "{src,lib}/*.c");
     defer allocator.free(pattern);
@@ -560,10 +566,11 @@ test "ZLOB_BRACE filesystem - C source and header files" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "src/*.{c,h}");
     defer allocator.free(pattern);
@@ -596,10 +603,11 @@ test "ZLOB_BRACE filesystem - recursive with extension alternatives" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "**/*.{c,h}");
     defer allocator.free(pattern);
@@ -634,10 +642,11 @@ test "ZLOB_BRACE filesystem - recursive with directory alternatives" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "{src,lib}/**/*.c");
     defer allocator.free(pattern);
@@ -662,10 +671,11 @@ test "ZLOB_BRACE filesystem - complex pattern with multiple brace groups" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "{src,lib}/**/*.{c,h}");
     defer allocator.free(pattern);
@@ -693,10 +703,11 @@ test "ZLOB_BRACE filesystem - single alternative (should still work)" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.{json}");
     defer allocator.free(pattern);
@@ -720,10 +731,11 @@ test "ZLOB_BRACE filesystem - many alternatives" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.{json,yaml,yml,toml,lock,md,txt,css,js,ts}");
     defer allocator.free(pattern);
@@ -747,10 +759,11 @@ test "ZLOB_BRACE filesystem - no matches returns NOMATCH" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.{xyz,abc,nonexistent}");
     defer allocator.free(pattern);
@@ -772,10 +785,11 @@ test "ZLOB_BRACE filesystem - without flag treats braces as literal" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Without ZLOB_BRACE, {toml,lock} is treated as literal
     const pattern = try allocator.dupeZ(u8, "*.{toml,lock}");
@@ -803,10 +817,11 @@ test "ZLOB_BRACE filesystem - combined with ZLOB_MARK" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "{src,lib,docs}");
     defer allocator.free(pattern);
@@ -835,10 +850,11 @@ test "ZLOB_BRACE filesystem - combined with ZLOB_NOSORT" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.{toml,lock,json}");
     defer allocator.free(pattern);
@@ -862,10 +878,11 @@ test "ZLOB_BRACE filesystem - combined with ZLOB_NOCHECK" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.{nonexistent1,nonexistent2}");
     defer allocator.free(pattern);
@@ -890,10 +907,11 @@ test "ZLOB_BRACE filesystem - combined with ZLOB_ONLYDIR" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Pattern that could match both files and directories
     const pattern = try allocator.dupeZ(u8, "{src,lib,docs,README.md}/");
@@ -922,10 +940,11 @@ test "ZLOB_BRACE filesystem - with ZLOB_APPEND" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     var pzlob: zlob.zlob_t = undefined;
 
@@ -961,10 +980,11 @@ test "ZLOB_BRACE filesystem - many files with brace pattern" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Pattern that will scan many directories
     const pattern = try allocator.dupeZ(u8, "**/*.{c,h,txt,md,json,yaml,yml,toml,lock,css,js,ts}");
@@ -993,10 +1013,11 @@ test "ZLOB_BRACE filesystem - Cargo pattern (Rust project)" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "Cargo.{toml,lock}");
     defer allocator.free(pattern);
@@ -1021,10 +1042,11 @@ test "ZLOB_BRACE filesystem - documentation pattern" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "**/*.{md,txt}");
     defer allocator.free(pattern);
@@ -1048,10 +1070,11 @@ test "ZLOB_BRACE filesystem - web assets pattern" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.{js,ts,css}");
     defer allocator.free(pattern);
@@ -1075,10 +1098,11 @@ test "ZLOB_BRACE filesystem - config files pattern" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.{json,yaml,yml,toml}");
     defer allocator.free(pattern);
@@ -1102,10 +1126,11 @@ test "ZLOB_BRACE filesystem - header files in multiple directories" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "{src,lib,include}/**/*.h");
     defer allocator.free(pattern);
@@ -1139,10 +1164,11 @@ test "ZLOB_BRACE filesystem - wildcard dir with brace extension" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*/*.{c,h}");
     defer allocator.free(pattern);
@@ -1180,10 +1206,11 @@ test "ZLOB_BRACE filesystem - literal prefix with wildcard dir and brace extensi
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "src/*/*.{c,h}");
     defer allocator.free(pattern);
@@ -1208,10 +1235,11 @@ test "ZLOB_BRACE filesystem - question mark wildcard with brace extension" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "src/????.{c,h}");
     defer allocator.free(pattern);
@@ -1236,10 +1264,11 @@ test "ZLOB_BRACE filesystem - multiple wildcard dirs with brace extension" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*/*/*.{c,h}");
     defer allocator.free(pattern);
@@ -1266,10 +1295,11 @@ test "ZLOB_BRACE filesystem - brace dir AND wildcard dir AND brace extension" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_brace", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "{src,lib}/*/*.{c,h}");
     defer allocator.free(pattern);

--- a/test/test_errfunc.zig
+++ b/test/test_errfunc.zig
@@ -35,14 +35,16 @@ fn testErrorCallbackAbort(epath: [*:0]const u8, eerrno: c_int) callconv(.c) c_in
 test "errfunc is called on directory access error" {
     const allocator = testing.allocator;
 
+    const io = std.Io.Threaded.global_single_threaded.io();
+
     // Create a directory structure with a restricted directory
     const test_dir = "/tmp/test_errfunc_access";
-    std.fs.cwd().makeDir(test_dir) catch {};
-    defer std.fs.cwd().deleteTree(test_dir) catch {};
+    std.Io.Dir.cwd().createDir(io, test_dir, .default_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, test_dir) catch {};
 
     // Create a subdirectory
     const restricted_dir = test_dir ++ "/restricted";
-    std.fs.cwd().makeDir(restricted_dir) catch {};
+    std.Io.Dir.cwd().createDir(io, restricted_dir, .default_dir) catch {};
 
     // Remove read permissions
     var perm_buf: [256:0]u8 = undefined;
@@ -52,14 +54,14 @@ test "errfunc is called on directory access error" {
 
     // Create a file we can access
     const accessible_file = test_dir ++ "/test.txt";
-    var f = try std.fs.cwd().createFile(accessible_file, .{});
-    f.close();
+    var f = try std.Io.Dir.cwd().createFile(io, accessible_file, .{});
+    f.close(io);
 
     // Change to test directory
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir);
-    defer std.posix.chdir(old_cwd) catch {};
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Try to glob with errfunc
     const pattern = try allocator.dupeZ(u8, "*/*");
@@ -77,15 +79,16 @@ test "errfunc is called on directory access error" {
 
 test "errfunc returning non-zero causes ZLOB_ABORTED" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create a directory structure with a restricted directory
     const test_dir = "/tmp/test_errfunc_abort";
-    std.fs.cwd().makeDir(test_dir) catch {};
-    defer std.fs.cwd().deleteTree(test_dir) catch {};
+    std.Io.Dir.cwd().createDir(io, test_dir, .default_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, test_dir) catch {};
 
     // Create a subdirectory
     const restricted_dir = test_dir ++ "/restricted";
-    std.fs.cwd().makeDir(restricted_dir) catch {};
+    std.Io.Dir.cwd().createDir(io, restricted_dir, .default_dir) catch {};
 
     // Remove read permissions
     var perm_buf: [256:0]u8 = undefined;
@@ -97,10 +100,10 @@ test "errfunc returning non-zero causes ZLOB_ABORTED" {
     if (chmod_result != 0) return error.SkipZigTest;
 
     // Change to test directory
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir);
-    defer std.posix.chdir(old_cwd) catch {};
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Try to glob with errfunc that returns non-zero
     const pattern = try allocator.dupeZ(u8, "*/*");
@@ -118,15 +121,16 @@ test "errfunc returning non-zero causes ZLOB_ABORTED" {
 
 test "ZLOB_ERR flag causes abort on directory error" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create a directory structure with a restricted directory
     const test_dir = "/tmp/test_zlob_err_flag";
-    std.fs.cwd().makeDir(test_dir) catch {};
-    defer std.fs.cwd().deleteTree(test_dir) catch {};
+    std.Io.Dir.cwd().createDir(io, test_dir, .default_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, test_dir) catch {};
 
     // Create a subdirectory
     const restricted_dir = test_dir ++ "/restricted";
-    std.fs.cwd().makeDir(restricted_dir) catch {};
+    std.Io.Dir.cwd().createDir(io, restricted_dir, .default_dir) catch {};
 
     // Remove read permissions
     var perm_buf: [256:0]u8 = undefined;
@@ -138,10 +142,10 @@ test "ZLOB_ERR flag causes abort on directory error" {
     if (chmod_result != 0) return error.SkipZigTest;
 
     // Change to test directory
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir);
-    defer std.posix.chdir(old_cwd) catch {};
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Try to glob with ZLOB_ERR flag
     const pattern = try allocator.dupeZ(u8, "*/*");
@@ -157,14 +161,15 @@ test "ZLOB_ERR flag causes abort on directory error" {
 
 test "errfunc NULL with ZLOB_ERR still aborts" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create a directory structure with a restricted directory
     const test_dir = "/tmp/test_null_errfunc";
-    std.fs.cwd().makeDir(test_dir) catch {};
-    defer std.fs.cwd().deleteTree(test_dir) catch {};
+    std.Io.Dir.cwd().createDir(io, test_dir, .default_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, test_dir) catch {};
 
     const restricted_dir = test_dir ++ "/restricted";
-    std.fs.cwd().makeDir(restricted_dir) catch {};
+    std.Io.Dir.cwd().createDir(io, restricted_dir, .default_dir) catch {};
 
     var perm_buf: [256:0]u8 = undefined;
     const perm_path = try std.fmt.bufPrintZ(&perm_buf, "{s}", .{restricted_dir});
@@ -174,10 +179,10 @@ test "errfunc NULL with ZLOB_ERR still aborts" {
     // Skip test if chmod failed
     if (chmod_result != 0) return error.SkipZigTest;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir);
-    defer std.posix.chdir(old_cwd) catch {};
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*/*");
     defer allocator.free(pattern);

--- a/test/test_gitignore_e2e.zig
+++ b/test/test_gitignore_e2e.zig
@@ -8,14 +8,15 @@ const ZlobFlags = zlob.ZlobFlags;
 // and verifies that glob correctly filters out ignored files and directories.
 test "gitignore e2e - target directory is filtered" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create unique temp directory
     var tmp_dir_buf: [256]u8 = undefined;
-    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_e2e_{d}", .{std.time.milliTimestamp()});
+    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_e2e_{d}", .{std.Io.Timestamp.now(io, .real).toMilliseconds()});
 
     // Create temp directory
-    try std.fs.makeDirAbsolute(tmp_dir);
-    defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std.Io.Dir.createDirAbsolute(io, tmp_dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, tmp_dir) catch {};
 
     // Create directory structure:
     // tmp/
@@ -41,7 +42,7 @@ test "gitignore e2e - target directory is filtered" {
     for (dirs) |dir| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, dir });
-        try std.fs.makeDirAbsolute(full_path);
+        try std.Io.Dir.createDirAbsolute(io, full_path, .default_dir);
     }
 
     // Create files
@@ -56,17 +57,17 @@ test "gitignore e2e - target directory is filtered" {
     for (files) |file| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, file });
-        const f = try std.fs.createFileAbsolute(full_path, .{});
-        f.close();
+        var f = try std.Io.Dir.createFileAbsolute(io, full_path, .{});
+        f.close(io);
     }
 
     // Create .gitignore file
     {
         var gitignore_path_buf: [512]u8 = undefined;
         const gitignore_path = try std.fmt.bufPrint(&gitignore_path_buf, "{s}/.gitignore", .{tmp_dir});
-        const gitignore_file = try std.fs.createFileAbsolute(gitignore_path, .{});
-        defer gitignore_file.close();
-        try gitignore_file.writeAll("target/\n");
+        var gitignore_file = try std.Io.Dir.createFileAbsolute(io, gitignore_path, .{});
+        defer gitignore_file.close(io);
+        try gitignore_file.writeStreamingAll(io, "target/\n");
     }
 
     // Test 1: Without gitignore flag - should find ALL .rs files including target/
@@ -77,7 +78,7 @@ test "gitignore e2e - target directory is filtered" {
         var flags = ZlobFlags.recommended();
         flags.gitignore = false; // Explicitly disable gitignore
 
-        var result = try zlob.match(allocator, pattern, flags);
+        var result = try zlob.match(allocator, io, pattern, flags);
         try testing.expect(result != null);
         defer result.?.deinit();
 
@@ -101,16 +102,15 @@ test "gitignore e2e - target directory is filtered" {
     // Test 2: With gitignore flag - should NOT find files in target/
     {
         // Change to temp dir to test gitignore loading from CWD
-        const original_cwd = std.fs.cwd();
-        var tmp_dir_handle = try std.fs.openDirAbsolute(tmp_dir, .{});
-        defer tmp_dir_handle.close();
-        try tmp_dir_handle.setAsCwd();
-        defer original_cwd.setAsCwd() catch {};
+        const original_cwd = try std.process.currentPathAlloc(io, allocator);
+        defer allocator.free(original_cwd);
+        try std.process.setCurrentPath(io, tmp_dir);
+        defer std.process.setCurrentPath(io, original_cwd) catch {};
 
         var flags = ZlobFlags.recommended();
         flags.gitignore = true; // Enable gitignore
 
-        var result = try zlob.match(allocator, "./**/*.rs", flags);
+        var result = try zlob.match(allocator, io, "./**/*.rs", flags);
         try testing.expect(result != null);
         defer result.?.deinit();
 
@@ -142,14 +142,15 @@ test "gitignore e2e - target directory is filtered" {
 
 test "gitignore e2e - node_modules directory is filtered" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create unique temp directory
     var tmp_dir_buf: [256]u8 = undefined;
-    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_node_{d}", .{std.time.milliTimestamp()});
+    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_node_{d}", .{std.Io.Timestamp.now(io, .real).toMilliseconds()});
 
     // Create temp directory
-    try std.fs.makeDirAbsolute(tmp_dir);
-    defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std.Io.Dir.createDirAbsolute(io, tmp_dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, tmp_dir) catch {};
 
     // Create directory structure for a Node.js project
     const dirs = [_][]const u8{
@@ -162,7 +163,7 @@ test "gitignore e2e - node_modules directory is filtered" {
     for (dirs) |dir| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, dir });
-        try std.fs.makeDirAbsolute(full_path);
+        try std.Io.Dir.createDirAbsolute(io, full_path, .default_dir);
     }
 
     // Create files
@@ -176,31 +177,30 @@ test "gitignore e2e - node_modules directory is filtered" {
     for (files_to_create) |file| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, file });
-        const f = try std.fs.createFileAbsolute(full_path, .{});
-        f.close();
+        var f = try std.Io.Dir.createFileAbsolute(io, full_path, .{});
+        f.close(io);
     }
 
     // Create .gitignore file
     {
         var gitignore_path_buf: [512]u8 = undefined;
         const gitignore_path = try std.fmt.bufPrint(&gitignore_path_buf, "{s}/.gitignore", .{tmp_dir});
-        const gitignore_file = try std.fs.createFileAbsolute(gitignore_path, .{});
-        defer gitignore_file.close();
-        try gitignore_file.writeAll("node_modules/\n");
+        var gitignore_file = try std.Io.Dir.createFileAbsolute(io, gitignore_path, .{});
+        defer gitignore_file.close(io);
+        try gitignore_file.writeStreamingAll(io, "node_modules/\n");
     }
 
     // Change to temp dir
-    const original_cwd = std.fs.cwd();
-    var tmp_dir_handle = try std.fs.openDirAbsolute(tmp_dir, .{});
-    defer tmp_dir_handle.close();
-    try tmp_dir_handle.setAsCwd();
-    defer original_cwd.setAsCwd() catch {};
+    const original_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(original_cwd);
+    try std.process.setCurrentPath(io, tmp_dir);
+    defer std.process.setCurrentPath(io, original_cwd) catch {};
 
     // Test with gitignore enabled
     var flags = ZlobFlags.recommended();
     flags.gitignore = true;
 
-    var result = try zlob.match(allocator, "./**/*.js", flags);
+    var result = try zlob.match(allocator, io, "./**/*.js", flags);
     try testing.expect(result != null);
     defer result.?.deinit();
 
@@ -218,14 +218,15 @@ test "gitignore e2e - node_modules directory is filtered" {
 
 test "gitignore e2e - wildcard patterns" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create unique temp directory
     var tmp_dir_buf: [256]u8 = undefined;
-    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_wild_{d}", .{std.time.milliTimestamp()});
+    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_wild_{d}", .{std.Io.Timestamp.now(io, .real).toMilliseconds()});
 
     // Create temp directory
-    try std.fs.makeDirAbsolute(tmp_dir);
-    defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std.Io.Dir.createDirAbsolute(io, tmp_dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, tmp_dir) catch {};
 
     // Create directory structure
     const dirs = [_][]const u8{
@@ -235,7 +236,7 @@ test "gitignore e2e - wildcard patterns" {
     for (dirs) |dir| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, dir });
-        try std.fs.makeDirAbsolute(full_path);
+        try std.Io.Dir.createDirAbsolute(io, full_path, .default_dir);
     }
 
     // Create files - mix of .o files and source files
@@ -249,31 +250,30 @@ test "gitignore e2e - wildcard patterns" {
     for (files_to_create) |file| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, file });
-        const f = try std.fs.createFileAbsolute(full_path, .{});
-        f.close();
+        var f = try std.Io.Dir.createFileAbsolute(io, full_path, .{});
+        f.close(io);
     }
 
     // Create .gitignore file with wildcard pattern
     {
         var gitignore_path_buf: [512]u8 = undefined;
         const gitignore_path = try std.fmt.bufPrint(&gitignore_path_buf, "{s}/.gitignore", .{tmp_dir});
-        const gitignore_file = try std.fs.createFileAbsolute(gitignore_path, .{});
-        defer gitignore_file.close();
-        try gitignore_file.writeAll("*.o\n");
+        var gitignore_file = try std.Io.Dir.createFileAbsolute(io, gitignore_path, .{});
+        defer gitignore_file.close(io);
+        try gitignore_file.writeStreamingAll(io, "*.o\n");
     }
 
     // Change to temp dir
-    const original_cwd = std.fs.cwd();
-    var tmp_dir_handle = try std.fs.openDirAbsolute(tmp_dir, .{});
-    defer tmp_dir_handle.close();
-    try tmp_dir_handle.setAsCwd();
-    defer original_cwd.setAsCwd() catch {};
+    const original_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(original_cwd);
+    try std.process.setCurrentPath(io, tmp_dir);
+    defer std.process.setCurrentPath(io, original_cwd) catch {};
 
     // Test with gitignore enabled - search for all files
     var flags = ZlobFlags.recommended();
     flags.gitignore = true;
 
-    var result = try zlob.match(allocator, "./**/*.*", flags);
+    var result = try zlob.match(allocator, io, "./**/*.*", flags);
     try testing.expect(result != null);
     defer result.?.deinit();
 
@@ -307,14 +307,15 @@ test "gitignore e2e - wildcard patterns" {
 // so files inside ignored directories are still returned.
 test "gitignore e2e - anchored directory patterns (rust/target/)" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create unique temp directory
     var tmp_dir_buf: [256]u8 = undefined;
-    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_anchored_{d}", .{std.time.milliTimestamp()});
+    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_anchored_{d}", .{std.Io.Timestamp.now(io, .real).toMilliseconds()});
 
     // Create temp directory
-    try std.fs.makeDirAbsolute(tmp_dir);
-    defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std.Io.Dir.createDirAbsolute(io, tmp_dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, tmp_dir) catch {};
 
     // Create directory structure similar to a monorepo with rust subproject:
     // tmp/
@@ -338,7 +339,7 @@ test "gitignore e2e - anchored directory patterns (rust/target/)" {
     for (dirs) |dir| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, dir });
-        try std.fs.makeDirAbsolute(full_path);
+        try std.Io.Dir.createDirAbsolute(io, full_path, .default_dir);
     }
 
     // Create files
@@ -351,32 +352,31 @@ test "gitignore e2e - anchored directory patterns (rust/target/)" {
     for (files_to_create) |file| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, file });
-        const f = try std.fs.createFileAbsolute(full_path, .{});
-        f.close();
+        var f = try std.Io.Dir.createFileAbsolute(io, full_path, .{});
+        f.close(io);
     }
 
     // Create .gitignore file with ANCHORED pattern (contains /)
     {
         var gitignore_path_buf: [512]u8 = undefined;
         const gitignore_path = try std.fmt.bufPrint(&gitignore_path_buf, "{s}/.gitignore", .{tmp_dir});
-        const gitignore_file = try std.fs.createFileAbsolute(gitignore_path, .{});
-        defer gitignore_file.close();
+        var gitignore_file = try std.Io.Dir.createFileAbsolute(io, gitignore_path, .{});
+        defer gitignore_file.close(io);
         // This pattern is anchored because it contains / before the trailing /
-        try gitignore_file.writeAll("rust/target/\n");
+        try gitignore_file.writeStreamingAll(io, "rust/target/\n");
     }
 
     // Change to temp dir
-    const original_cwd = std.fs.cwd();
-    var tmp_dir_handle = try std.fs.openDirAbsolute(tmp_dir, .{});
-    defer tmp_dir_handle.close();
-    try tmp_dir_handle.setAsCwd();
-    defer original_cwd.setAsCwd() catch {};
+    const original_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(original_cwd);
+    try std.process.setCurrentPath(io, tmp_dir);
+    defer std.process.setCurrentPath(io, original_cwd) catch {};
 
     // Test with gitignore enabled
     var flags = ZlobFlags.recommended();
     flags.gitignore = true;
 
-    var result = try zlob.match(allocator, "./**/*.rs", flags);
+    var result = try zlob.match(allocator, io, "./**/*.rs", flags);
     try testing.expect(result != null);
     defer result.?.deinit();
 
@@ -395,14 +395,15 @@ test "gitignore e2e - anchored directory patterns (rust/target/)" {
 
 test "gitignore e2e - negation patterns" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create unique temp directory
     var tmp_dir_buf: [256]u8 = undefined;
-    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_neg_{d}", .{std.time.milliTimestamp()});
+    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_neg_{d}", .{std.Io.Timestamp.now(io, .real).toMilliseconds()});
 
     // Create temp directory
-    try std.fs.makeDirAbsolute(tmp_dir);
-    defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std.Io.Dir.createDirAbsolute(io, tmp_dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, tmp_dir) catch {};
 
     // Create directory structure
     const dirs = [_][]const u8{
@@ -411,7 +412,7 @@ test "gitignore e2e - negation patterns" {
     for (dirs) |dir| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, dir });
-        try std.fs.makeDirAbsolute(full_path);
+        try std.Io.Dir.createDirAbsolute(io, full_path, .default_dir);
     }
 
     // Create files
@@ -424,32 +425,31 @@ test "gitignore e2e - negation patterns" {
     for (files_to_create) |file| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, file });
-        const f = try std.fs.createFileAbsolute(full_path, .{});
-        f.close();
+        var f = try std.Io.Dir.createFileAbsolute(io, full_path, .{});
+        f.close(io);
     }
 
     // Create .gitignore file with negation pattern
     {
         var gitignore_path_buf: [512]u8 = undefined;
         const gitignore_path = try std.fmt.bufPrint(&gitignore_path_buf, "{s}/.gitignore", .{tmp_dir});
-        const gitignore_file = try std.fs.createFileAbsolute(gitignore_path, .{});
-        defer gitignore_file.close();
+        var gitignore_file = try std.Io.Dir.createFileAbsolute(io, gitignore_path, .{});
+        defer gitignore_file.close(io);
         // Ignore all .log files except important.log
-        try gitignore_file.writeAll("*.log\n!important.log\n");
+        try gitignore_file.writeStreamingAll(io, "*.log\n!important.log\n");
     }
 
     // Change to temp dir
-    const original_cwd = std.fs.cwd();
-    var tmp_dir_handle = try std.fs.openDirAbsolute(tmp_dir, .{});
-    defer tmp_dir_handle.close();
-    try tmp_dir_handle.setAsCwd();
-    defer original_cwd.setAsCwd() catch {};
+    const original_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(original_cwd);
+    try std.process.setCurrentPath(io, tmp_dir);
+    defer std.process.setCurrentPath(io, original_cwd) catch {};
 
     // Test with gitignore enabled
     var flags = ZlobFlags.recommended();
     flags.gitignore = true;
 
-    var result = try zlob.match(allocator, "./**/*.log", flags);
+    var result = try zlob.match(allocator, io, "./**/*.log", flags);
     try testing.expect(result != null);
     defer result.?.deinit();
 
@@ -462,14 +462,15 @@ test "gitignore e2e - negation patterns" {
 
 test "gitignore e2e - negated subdirectory of ignored directory" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Create unique temp directory
     var tmp_dir_buf: [256]u8 = undefined;
-    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_negdir_{d}", .{std.time.milliTimestamp()});
+    const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_gitignore_negdir_{d}", .{std.Io.Timestamp.now(io, .real).toMilliseconds()});
 
     // Create temp directory
-    try std.fs.makeDirAbsolute(tmp_dir);
-    defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+    try std.Io.Dir.createDirAbsolute(io, tmp_dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, tmp_dir) catch {};
 
     // Create directory structure:
     // tmp/
@@ -494,7 +495,7 @@ test "gitignore e2e - negated subdirectory of ignored directory" {
     for (dirs) |dir| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, dir });
-        try std.fs.makeDirAbsolute(full_path);
+        try std.Io.Dir.createDirAbsolute(io, full_path, .default_dir);
     }
 
     // Create files
@@ -506,32 +507,31 @@ test "gitignore e2e - negated subdirectory of ignored directory" {
     for (files_to_create) |file| {
         var path_buf: [512]u8 = undefined;
         const full_path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ tmp_dir, file });
-        const f = try std.fs.createFileAbsolute(full_path, .{});
-        f.close();
+        var f = try std.Io.Dir.createFileAbsolute(io, full_path, .{});
+        f.close(io);
     }
 
     // Create .gitignore file with negation for subdirectory
     {
         var gitignore_path_buf: [512]u8 = undefined;
         const gitignore_path = try std.fmt.bufPrint(&gitignore_path_buf, "{s}/.gitignore", .{tmp_dir});
-        const gitignore_file = try std.fs.createFileAbsolute(gitignore_path, .{});
-        defer gitignore_file.close();
+        var gitignore_file = try std.Io.Dir.createFileAbsolute(io, gitignore_path, .{});
+        defer gitignore_file.close(io);
         // Ignore rust/target/ but NOT rust/target/rust-analyzer/
-        try gitignore_file.writeAll("rust/target/\n!rust/target/rust-analyzer/\n");
+        try gitignore_file.writeStreamingAll(io, "rust/target/\n!rust/target/rust-analyzer/\n");
     }
 
     // Change to temp dir
-    const original_cwd = std.fs.cwd();
-    var tmp_dir_handle = try std.fs.openDirAbsolute(tmp_dir, .{});
-    defer tmp_dir_handle.close();
-    try tmp_dir_handle.setAsCwd();
-    defer original_cwd.setAsCwd() catch {};
+    const original_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(original_cwd);
+    try std.process.setCurrentPath(io, tmp_dir);
+    defer std.process.setCurrentPath(io, original_cwd) catch {};
 
     // Test with gitignore enabled
     var flags = ZlobFlags.recommended();
     flags.gitignore = true;
 
-    var result = try zlob.match(allocator, "./**/*.rs", flags);
+    var result = try zlob.match(allocator, io, "./**/*.rs", flags);
     try testing.expect(result != null);
     defer result.?.deinit();
 

--- a/test/test_glibc.zig
+++ b/test/test_glibc.zig
@@ -49,20 +49,23 @@ fn createTestDirStructure(allocator: std.mem.Allocator, base_path: []const u8) !
         _ = c.mkdir(&path_z, 0o755);
     }
 
+    const io = std.Io.Threaded.global_single_threaded.io();
+
     // Create all files
     for (files) |file| {
         const full_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ base_path, file });
         defer allocator.free(full_path);
 
-        const f = std.fs.cwd().createFile(full_path, .{}) catch continue;
-        defer f.close();
+        var f = std.Io.Dir.cwd().createFile(io, full_path, .{}) catch continue;
+        defer f.close(io);
         const content = "test content\n";
-        _ = f.write(content) catch {};
+        _ = f.writeStreamingAll(io, content) catch {};
     }
 }
 
 // Helper to cleanup test directory structure
 fn cleanupTestDirStructure(allocator: std.mem.Allocator, base_path: []const u8) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const full_path_str = try std.fmt.allocPrint(allocator, "{s}/test_zlob_recursive", .{base_path});
     defer allocator.free(full_path_str);
 
@@ -71,8 +74,7 @@ fn cleanupTestDirStructure(allocator: std.mem.Allocator, base_path: []const u8) 
     full_path[full_path_str.len] = 0;
 
     // Use system rm -rf to recursively delete
-    const result = std.process.Child.run(.{
-        .allocator = allocator,
+    const result = std.process.run(allocator, io, .{
         .argv = &[_][]const u8{ "rm", "-rf", full_path_str },
     }) catch return;
     allocator.free(result.stdout);
@@ -96,12 +98,13 @@ test "recursive glob - **/*.c finds all C files" {
     test_dir[test_dir_str.len] = 0;
 
     // Save current directory
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
 
     // Change to test directory
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "**/*.c");
     defer allocator.free(pattern);
@@ -131,10 +134,11 @@ test "recursive glob - dir1/**/*.c finds C files in dir1" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "dir1/**/*.c");
     defer allocator.free(pattern);
@@ -162,10 +166,11 @@ test "recursive glob - **/*.h finds all header files" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "**/*.h");
     defer allocator.free(pattern);
@@ -193,10 +198,11 @@ test "recursive glob - dir2/**/*.c finds files in dir2 subdirectories" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "dir2/**/*.c");
     defer allocator.free(pattern);
@@ -224,10 +230,11 @@ test "recursive glob - **/*.txt finds all text files" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "**/*.txt");
     defer allocator.free(pattern);
@@ -255,10 +262,11 @@ test "recursive glob - no matches returns ZLOB_NOMATCH" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "**/*.nonexistent");
     defer allocator.free(pattern);
@@ -284,10 +292,11 @@ test "recursive glob - ZLOB_APPEND correctly accumulates results" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     var pzlob: glob.zlob_t = undefined;
 
@@ -324,10 +333,11 @@ test "recursive glob - empty pattern component" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "**/");
     defer allocator.free(pattern);
@@ -354,10 +364,11 @@ test "glibc compatible - ** treated as * without ZLOB_DOUBLESTAR_RECURSIVE" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Test: Pattern "**/*.c" WITHOUT ZLOB_DOUBLESTAR_RECURSIVE flag
     // Expected behavior (matching glibc):

--- a/test/test_posix.zig
+++ b/test/test_posix.zig
@@ -5,6 +5,16 @@ const zlob_flags = @import("zlob_flags");
 const c_lib = @import("c_lib");
 const c = std.c;
 
+/// Look up an environment variable via libc's getenv.
+fn getenv(name: []const u8) ?[]const u8 {
+    var name_buf: [256]u8 = undefined;
+    if (name.len + 1 > name_buf.len) return null;
+    @memcpy(name_buf[0..name.len], name);
+    name_buf[name.len] = 0;
+    const ptr = std.c.getenv(@ptrCast(&name_buf)) orelse return null;
+    return std.mem.sliceTo(ptr, 0);
+}
+
 // Test structure helper
 fn createTestFiles(allocator: std.mem.Allocator, base_path: []const u8) !void {
     const dirs = [_][]const u8{
@@ -34,24 +44,26 @@ fn createTestFiles(allocator: std.mem.Allocator, base_path: []const u8) !void {
         _ = c.mkdir(&path_z, 0o755);
     }
 
+    const io = std.Io.Threaded.global_single_threaded.io();
+
     // Create files
     for (files) |file| {
         const full_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ base_path, file });
         defer allocator.free(full_path);
 
-        const f = std.fs.cwd().createFile(full_path, .{}) catch continue;
-        defer f.close();
+        var f = std.Io.Dir.cwd().createFile(io, full_path, .{}) catch continue;
+        defer f.close(io);
         const content = "test content\n";
-        _ = f.write(content) catch {};
+        _ = f.writeStreamingAll(io, content) catch {};
     }
 }
 
 fn cleanupTestFiles(allocator: std.mem.Allocator, base_path: []const u8) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     const full_path_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{base_path});
     defer allocator.free(full_path_str);
 
-    const result = std.process.Child.run(.{
-        .allocator = allocator,
+    const result = std.process.run(allocator, io, .{
         .argv = &[_][]const u8{ "rm", "-rf", full_path_str },
     }) catch return;
     allocator.free(result.stdout);
@@ -76,10 +88,11 @@ test "ZLOB_MARK - appends slash to directories" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*");
     defer allocator.free(pattern);
@@ -119,10 +132,11 @@ test "ZLOB_MARK - does not append slash to files" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.txt");
     defer allocator.free(pattern);
@@ -155,10 +169,11 @@ test "ZLOB_MARK - works with recursive glob" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "**/");
     defer allocator.free(pattern);
@@ -195,10 +210,11 @@ test "ZLOB_DOOFFS - reserves offset slots at beginning" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*.txt");
     defer allocator.free(pattern);
@@ -239,10 +255,11 @@ test "ZLOB_DOOFFS - works with ZLOB_APPEND" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     var pzlob: glob.zlob_t = undefined;
     pzlob.zlo_offs = 2;
@@ -286,10 +303,11 @@ test "ZLOB_PERIOD - matches hidden files with wildcard" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Define ZLOB_PERIOD
     const ZLOB_PERIOD = zlob_flags.ZLOB_PERIOD;
@@ -330,10 +348,11 @@ test "ZLOB_PERIOD - without flag does not match hidden files" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "*");
     defer allocator.free(pattern);
@@ -365,10 +384,11 @@ test "ZLOB_PERIOD - explicit dot still matches" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, ".*");
     defer allocator.free(pattern);
@@ -396,17 +416,18 @@ test "ZLOB_PERIOD - explicit dot still matches" {
 
 test "ZLOB_TILDE - expands tilde to home directory" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Get $HOME environment variable
-    const home = std.posix.getenv("HOME") orelse return error.SkipZigTest;
+    const home = getenv("HOME") orelse return error.SkipZigTest;
 
     // Create a test file in home directory
     const test_file = try std.fmt.allocPrint(allocator, "{s}/.zlob_test_tilde_12345.txt", .{home});
     defer allocator.free(test_file);
 
-    const f = std.fs.cwd().createFile(test_file, .{}) catch return error.SkipZigTest;
-    f.close();
-    defer std.fs.cwd().deleteFile(test_file) catch {};
+    var f = std.Io.Dir.cwd().createFile(io, test_file, .{}) catch return error.SkipZigTest;
+    f.close(io);
+    defer std.Io.Dir.cwd().deleteFile(io, test_file) catch {};
 
     const pattern = try allocator.dupeZ(u8, "~/.zlob_test_tilde_*.txt");
     defer allocator.free(pattern);
@@ -424,18 +445,19 @@ test "ZLOB_TILDE - expands tilde to home directory" {
 
 test "ZLOB_TILDE - expands ~username to user home" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Get current username
-    const username = std.posix.getenv("USER") orelse return error.SkipZigTest;
-    const home = std.posix.getenv("HOME") orelse return error.SkipZigTest;
+    const username = getenv("USER") orelse return error.SkipZigTest;
+    const home = getenv("HOME") orelse return error.SkipZigTest;
 
     // Create test file
     const test_file = try std.fmt.allocPrint(allocator, "{s}/.zlob_test_user_12345.txt", .{home});
     defer allocator.free(test_file);
 
-    const f = std.fs.cwd().createFile(test_file, .{}) catch return error.SkipZigTest;
-    f.close();
-    defer std.fs.cwd().deleteFile(test_file) catch {};
+    var f = std.Io.Dir.cwd().createFile(io, test_file, .{}) catch return error.SkipZigTest;
+    f.close(io);
+    defer std.Io.Dir.cwd().deleteFile(io, test_file) catch {};
 
     const pattern_str = try std.fmt.allocPrint(allocator, "~{s}/.zlob_test_user_*.txt", .{username});
     defer allocator.free(pattern_str);
@@ -524,10 +546,11 @@ test "ZLOB_NOMAGIC - returns pattern for literal with no match" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Literal pattern (no wildcards) that doesn't exist - should return the
     // pattern itself as a result (BSD NOMAGIC acts like NOCHECK for literals)
@@ -558,10 +581,11 @@ test "ZLOB_NOMAGIC - returns NOMATCH for wildcard pattern with no match" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Pattern with wildcards that doesn't match - NOMAGIC does NOT help here,
     // because the pattern has magic characters. Returns NOMATCH.
@@ -588,10 +612,11 @@ test "ZLOB_NOMAGIC - succeeds normally for wildcard pattern with matches" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Wildcard pattern that matches - normal glob behavior, NOMAGIC irrelevant
     const pattern = try allocator.dupeZ(u8, "*.txt");
@@ -623,10 +648,11 @@ test "ZLOB_MARK and ZLOB_PERIOD together" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const ZLOB_PERIOD = zlob_flags.ZLOB_PERIOD;
 
@@ -652,21 +678,22 @@ test "ZLOB_MARK and ZLOB_PERIOD together" {
 
 test "ZLOB_TILDE with recursive glob" {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    const home = std.posix.getenv("HOME") orelse return error.SkipZigTest;
+    const home = getenv("HOME") orelse return error.SkipZigTest;
 
     // Create nested test directory in home
     const test_dir_path = try std.fmt.allocPrint(allocator, "{s}/.zlob_test_nested", .{home});
     defer allocator.free(test_dir_path);
 
-    std.fs.cwd().makeDir(test_dir_path) catch {};
-    defer std.fs.cwd().deleteTree(test_dir_path) catch {};
+    std.Io.Dir.cwd().createDir(io, test_dir_path, .default_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, test_dir_path) catch {};
 
     const test_file = try std.fmt.allocPrint(allocator, "{s}/test.txt", .{test_dir_path});
     defer allocator.free(test_file);
 
-    const f = std.fs.cwd().createFile(test_file, .{}) catch return error.SkipZigTest;
-    f.close();
+    var f = std.Io.Dir.cwd().createFile(io, test_file, .{}) catch return error.SkipZigTest;
+    f.close(io);
 
     const pattern = try allocator.dupeZ(u8, "~/**/.zlob_test_nested/*.txt");
     defer allocator.free(pattern);
@@ -697,10 +724,11 @@ test "ZLOB_PERIOD - recursive glob should not match hidden files by default" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Test with ** recursive pattern - should NOT match hidden files without ZLOB_PERIOD
     const pattern = try allocator.dupeZ(u8, "**/*");
@@ -749,10 +777,11 @@ test "ZLOB_PERIOD - recursive glob matches hidden files with flag" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const ZLOB_PERIOD = zlob_flags.ZLOB_PERIOD;
 
@@ -808,10 +837,11 @@ test "ZLOB_PERIOD - explicit dot pattern still matches without flag in recursive
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Pattern explicitly starts with . - should match even without ZLOB_PERIOD
     const pattern = try allocator.dupeZ(u8, "**/.hidden*");
@@ -848,10 +878,11 @@ test "literal path - file exists" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "file1.txt");
     defer allocator.free(pattern);
@@ -876,10 +907,11 @@ test "literal path - directory exists" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "dir1");
     defer allocator.free(pattern);
@@ -903,10 +935,11 @@ test "literal path - ZLOB_ONLYDIR with directory" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "dir1");
     defer allocator.free(pattern);
@@ -930,10 +963,11 @@ test "literal path - ZLOB_ONLYDIR with file (should fail)" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "file1.txt");
     defer allocator.free(pattern);
@@ -955,10 +989,11 @@ test "literal path - ZLOB_MARK with directory" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "dir1");
     defer allocator.free(pattern);
@@ -984,10 +1019,11 @@ test "literal path - ZLOB_MARK with file (no slash)" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "file1.txt");
     defer allocator.free(pattern);
@@ -1012,10 +1048,11 @@ test "literal path - ./ prefix normalization" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "./file1.txt");
     defer allocator.free(pattern);
@@ -1040,10 +1077,11 @@ test "literal path - ZLOB_NOCHECK returns pattern when not found" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "nonexistent.txt");
     defer allocator.free(pattern);
@@ -1068,10 +1106,11 @@ test "literal path - not found without ZLOB_NOCHECK" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "nonexistent.txt");
     defer allocator.free(pattern);
@@ -1093,10 +1132,11 @@ test "literal path - ZLOB_MARK and ZLOB_ONLYDIR together" {
     const test_dir_str = try std.fmt.allocPrint(allocator, "{s}/test_missing_flags", .{tmp_dir});
     defer allocator.free(test_dir_str);
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir_str);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir_str);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     const pattern = try allocator.dupeZ(u8, "dir1");
     defer allocator.free(pattern);
@@ -1315,10 +1355,11 @@ test "ZLOB_MAGCHAR - set when pattern has wildcards" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Test with wildcard pattern - ZLOB_MAGCHAR should be set
     const pattern = try allocator.dupeZ(u8, "*.c");
@@ -1348,10 +1389,11 @@ test "ZLOB_MAGCHAR - not set when pattern has no wildcards" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Test with literal pattern (no wildcards) - ZLOB_MAGCHAR should NOT be set
     const pattern = try allocator.dupeZ(u8, "file1.txt");
@@ -1381,10 +1423,11 @@ test "ZLOB_MAGCHAR - set with question mark wildcard" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Test with ? wildcard - ZLOB_MAGCHAR should be set
     const pattern = try allocator.dupeZ(u8, "file?.txt");
@@ -1414,10 +1457,11 @@ test "ZLOB_MAGCHAR - set with brace expansion when ZLOB_BRACE enabled" {
     @memcpy(test_dir[0..test_dir_str.len], test_dir_str);
     test_dir[test_dir_str.len] = 0;
 
-    var cwd_buf: [4096]u8 = undefined;
-    const old_cwd = try std.posix.getcwd(&cwd_buf);
-    try std.posix.chdir(test_dir[0..test_dir_str.len :0]);
-    defer std.posix.chdir(old_cwd) catch {};
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const old_cwd = try std.process.currentPathAlloc(io, allocator);
+    defer allocator.free(old_cwd);
+    try std.process.setCurrentPath(io, test_dir[0..test_dir_str.len :0]);
+    defer std.process.setCurrentPath(io, old_cwd) catch {};
 
     // Test with brace pattern and ZLOB_BRACE flag - ZLOB_MAGCHAR should be set
     const pattern = try allocator.dupeZ(u8, "file{1,2}.txt");

--- a/test/test_rust_glob.zig
+++ b/test/test_rust_glob.zig
@@ -13,12 +13,13 @@ const fs = std.fs;
 
 const TestDir = struct {
     dir: std.testing.TmpDir,
-    path: []const u8,
+    path: [:0]const u8,
     allocator: std.mem.Allocator,
 
     fn init(allocator: std.mem.Allocator) !TestDir {
-        const tmp = std.testing.tmpDir(.{});
-        const path = try tmp.dir.realpathAlloc(allocator, ".");
+        const io = std.Io.Threaded.global_single_threaded.io();
+        var tmp = std.testing.tmpDir(.{});
+        const path = try tmp.dir.realPathFileAlloc(io, ".", allocator);
         return .{
             .dir = tmp,
             .path = path,
@@ -32,15 +33,16 @@ const TestDir = struct {
     }
 
     fn mkFile(self: *TestDir, path: []const u8, is_directory: bool) !void {
+        const io = std.Io.Threaded.global_single_threaded.io();
         if (is_directory) {
-            try self.dir.dir.makePath(path);
+            try self.dir.dir.createDirPath(io, path);
         } else {
             // Ensure parent directories exist
             if (fs.path.dirname(path)) |parent| {
-                try self.dir.dir.makePath(parent);
+                try self.dir.dir.createDirPath(io, parent);
             }
-            const file = try self.dir.dir.createFile(path, .{});
-            file.close();
+            var file = try self.dir.dir.createFile(io, path, .{});
+            file.close(io);
         }
     }
 
@@ -61,14 +63,15 @@ const TestDir = struct {
     }
 
     fn globVec(self: *TestDir, allocator: std.mem.Allocator, pattern: []const u8) ![][]const u8 {
+        const io = std.Io.Threaded.global_single_threaded.io();
         // Change to test directory
-        const old_cwd = try std.process.getCwdAlloc(allocator);
+        const old_cwd = try std.process.currentPathAlloc(io, allocator);
         defer allocator.free(old_cwd);
-        try std.posix.chdir(self.path);
-        defer std.posix.chdir(old_cwd) catch {};
+        try std.process.setCurrentPath(io, self.path);
+        defer std.process.setCurrentPath(io, old_cwd) catch {};
 
         // Use match API - returns ?ZlobResults
-        var result = try zlob.match(allocator, pattern, 0) orelse {
+        var result = try zlob.match(allocator, io, pattern, 0) orelse {
             // No matches - return empty array
             return try allocator.alloc([]const u8, 0);
         };

--- a/test/test_utils.zig
+++ b/test/test_utils.zig
@@ -47,6 +47,7 @@ pub const TestResult = struct {
 pub const AssertFn = *const fn (result: TestResult) anyerror!void;
 
 fn makeDirRecursive(path: []const u8) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
     var path_buf: [4096]u8 = undefined;
     var pos: usize = 0;
 
@@ -54,12 +55,12 @@ fn makeDirRecursive(path: []const u8) !void {
         path_buf[pos] = char;
         pos += 1;
         if (char == '/' and pos > 1) {
-            std.fs.makeDirAbsolute(path_buf[0..pos]) catch |err| {
+            std.Io.Dir.createDirAbsolute(io, path_buf[0..pos], .default_dir) catch |err| {
                 if (err != error.PathAlreadyExists) continue;
             };
         }
     }
-    std.fs.makeDirAbsolute(path_buf[0..pos]) catch |err| {
+    std.Io.Dir.createDirAbsolute(io, path_buf[0..pos], .default_dir) catch |err| {
         if (err != error.PathAlreadyExists) return err;
     };
 }
@@ -114,6 +115,8 @@ pub fn zlobIsomorphicTest(
     // Part 2: Test with filesystem match
     // ========================================
     {
+        const io = std.Io.Threaded.global_single_threaded.io();
+
         // Create temp directory with unique name based on test name (from @src())
         // This is deterministic and avoids race conditions between parallel tests
         var tmp_dir_buf: [512]u8 = undefined;
@@ -127,10 +130,10 @@ pub fn zlobIsomorphicTest(
         const tmp_dir = try std.fmt.bufPrint(&tmp_dir_buf, "/tmp/zlob_test_{x}", .{hash});
 
         // Create the temp directory
-        std.fs.makeDirAbsolute(tmp_dir) catch |err| {
+        std.Io.Dir.createDirAbsolute(io, tmp_dir, .default_dir) catch |err| {
             if (err != error.PathAlreadyExists) return err;
         };
-        defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
+        defer std.Io.Dir.cwd().deleteTree(io, tmp_dir) catch {};
 
         // Create test files
         for (files) |file| {
@@ -143,8 +146,8 @@ pub fn zlobIsomorphicTest(
             }
 
             // Create the file
-            const f = try std.fs.createFileAbsolute(full_path, .{});
-            f.close();
+            const f = try std.Io.Dir.createFileAbsolute(io, full_path, .{});
+            f.close(io);
         }
 
         // Build full pattern with temp dir prefix
@@ -152,7 +155,7 @@ pub fn zlobIsomorphicTest(
         defer allocator.free(full_pattern);
 
         // Run filesystem glob
-        var fs_result_opt = try zlob.match(allocator, full_pattern, flags);
+        var fs_result_opt = try zlob.match(allocator, io, full_pattern, flags);
         if (fs_result_opt) |*fs_result| {
             defer fs_result.deinit();
 
@@ -217,12 +220,13 @@ pub fn testFilesystemOnly(
     assertFn: AssertFn,
 ) !void {
     const allocator = testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     // Build full pattern
     const full_pattern = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir_path, pattern });
     defer allocator.free(full_pattern);
 
-    var fs_result_opt = try zlob.match(allocator, full_pattern, flags);
+    var fs_result_opt = try zlob.match(allocator, io, full_pattern, flags);
     if (fs_result_opt) |*fs_result| {
         defer fs_result.deinit();
 


### PR DESCRIPTION
Public Zig API now takes an `io: std.Io` parameter so callers control the I/O implementation (`match`, `matchAt`, `glob`, `globSlice`, `globAt`, `GitIgnore.loadFromCwd`/`loadFromDir`, `DefaultWalker.init`, and the `DirIterator` / `StdDirIterator` constructors). The C ABI wrappers in `c_lib.zig` can't carry an `Io` across the boundary, so they internally use `std.Io.Threaded.global_single_threaded.io()`.

Also covers the rest of the 0.16 stdlib churn: `std.fs` → `std.Io.Dir`, `std.time.Timer`/`nanoTimestamp` → `std.Io.Timestamp`, `std.Thread.sleep` → `std.Io.sleep`, `std.process.changeCurDir` → `setCurrentPath`, `std.process.argsAlloc`/`argsWithAllocator` → juicy-main (`pub fn main(init: std.process.Init)`) with `std.process.Args.Iterator`, `std.process.getEnvVarOwned` → `std.c.getenv`,
`std.heap.GeneralPurposeAllocator` → `std.heap.DebugAllocator`, `std.ArrayList(T){}` → `.empty`, `std.mem.trimRight` → `trimEnd`, and `file.readToEndAlloc` → `dir.readFileAlloc(io, ..., .limited(N))`.

`minimum_zig_version` bumped to 0.16.0.

Disclamer: Used claude to help facilitate this migration