### PR TITLE
feat: add ZLOB_PATHNAME flag to prevent * and ? from matching /

### DIFF
--- a/include/zlob.h
+++ b/include/zlob.h
@@ -124,6 +124,8 @@ typedef struct {
 #define ZLOB_EXTGLOB                                                           \
   (1 << 26) /* Enable extended glob patterns: ?(pat) *(pat) +(pat) @(pat)      \
                !(pat) */
+#define ZLOB_PATHNAME                                                          \
+  (1 << 27) /* * and ? don't match / (like POSIX FNM_PATHNAME) */
 
 /* Recommended modern defaults for globbing:
  * - BRACE: Brace expansion {a,b,c}

--- a/rust/src/flags.rs
+++ b/rust/src/flags.rs
@@ -109,6 +109,28 @@ bitflags! {
         /// ```
         const EXTGLOB = ffi::ZLOB_EXTGLOB;
 
+        /// Prevent `*` and `?` from matching `/` (like POSIX `FNM_PATHNAME`).
+        ///
+        /// By default, `*` matches any character sequence including path separators.
+        /// With this flag, `*` stops at `/`, making patterns like `docs/*` match
+        /// only files directly inside `docs/` rather than arbitrarily deep paths.
+        ///
+        /// Has no effect when [`DOUBLESTAR_RECURSIVE`](ZlobFlags::DOUBLESTAR_RECURSIVE)
+        /// is set and the pattern contains `**`, since that path already uses
+        /// segment-by-segment matching.
+        ///
+        /// # Example
+        ///
+        /// ```
+        /// use zlob::{ZlobPattern, ZlobFlags};
+        ///
+        /// let flags = ZlobFlags::PATHNAME;
+        /// let pat = ZlobPattern::compile("docs/*", flags).unwrap();
+        /// assert!(pat.matches("docs/index.md", flags));
+        /// assert!(!pat.matches("docs/api/index.md", flags));
+        /// ```
+        const PATHNAME = ffi::ZLOB_PATHNAME;
+
         /// Recommended modern defaults for globbing.
         ///
         /// Enables: BRACE, DOUBLESTAR_RECURSIVE, NOSORT, TILDE, TILDE_CHECK
@@ -147,6 +169,7 @@ mod tests {
         assert_eq!(ZlobFlags::GITIGNORE.bits(), 1 << 24);
         assert_eq!(ZlobFlags::DOUBLESTAR_RECURSIVE.bits(), 1 << 25);
         assert_eq!(ZlobFlags::EXTGLOB.bits(), 1 << 26);
+        assert_eq!(ZlobFlags::PATHNAME.bits(), 1 << 27);
     }
 
     #[test]

--- a/src/compiled_pattern.zig
+++ b/src/compiled_pattern.zig
@@ -316,9 +316,9 @@ pub fn matchSinglePath(
 
     if (!pattern_segments.has_doublestar) {
         if (enable_extglob and containsExtglob(pattern_segments.original_pattern)) {
-            return fnmatch_mod.fnmatch(pattern_segments.original_pattern, path, .{ .extglob = true });
+            return fnmatch_mod.fnmatch(pattern_segments.original_pattern, path, .{ .extglob = true, .pathname = flags.pathname });
         }
-        return fnmatch_mod.fnmatch(pattern_segments.original_pattern, path, .{ .noescape = !enable_escapes });
+        return fnmatch_mod.fnmatch(pattern_segments.original_pattern, path, .{ .noescape = !enable_escapes, .pathname = flags.pathname });
     }
 
     var component_buffer: [MAX_PATH_COMPONENTS][]const u8 = undefined;

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -38,6 +38,7 @@ pub const ZLOB_TILDE_CHECK = c.ZLOB_TILDE_CHECK;
 pub const ZLOB_GITIGNORE = c.ZLOB_GITIGNORE;
 pub const ZLOB_DOUBLESTAR_RECURSIVE = c.ZLOB_DOUBLESTAR_RECURSIVE;
 pub const ZLOB_EXTGLOB = c.ZLOB_EXTGLOB;
+pub const ZLOB_PATHNAME = c.ZLOB_PATHNAME;
 pub const ZLOB_RECOMMENDED = c.ZLOB_RECOMMENDED;
 
 // Error codes
@@ -80,9 +81,10 @@ pub const ZlobFlags = packed struct(u32) {
     gitignore: bool = false,
     doublestar_recursive: bool = false,
     extglob: bool = false,
+    pathname: bool = false,
 
     // fill the rest of 32 bits
-    _padding: u5 = 0,
+    _padding: u4 = 0,
 
     pub fn recommended() ZlobFlags {
         return ZlobFlags{
@@ -140,6 +142,7 @@ pub const ZlobFlags = packed struct(u32) {
         std.debug.assert((ZlobFlags{ .gitignore = true }).toU32() == ZLOB_GITIGNORE);
         std.debug.assert((ZlobFlags{ .doublestar_recursive = true }).toU32() == ZLOB_DOUBLESTAR_RECURSIVE);
         std.debug.assert((ZlobFlags{ .extglob = true }).toU32() == ZLOB_EXTGLOB);
+        std.debug.assert((ZlobFlags{ .pathname = true }).toU32() == ZLOB_PATHNAME);
     }
 };
 

--- a/src/fnmatch.zig
+++ b/src/fnmatch.zig
@@ -33,7 +33,7 @@ pub inline fn fnmatch(pattern: []const u8, string: []const u8, flags: ZlobFlags)
     if (flags.extglob and containsExtglob(pattern)) {
         return matchExtglob(pattern, string);
     }
-    return fnmatchCore(pattern, string, !flags.noescape);
+    return fnmatchCore(pattern, string, !flags.noescape, flags.pathname);
 }
 
 /// Match using a pre-computed PatternContext for repeated matching against the same pattern.
@@ -63,10 +63,10 @@ pub inline fn fnmatchWithContext(ctx: *const PatternContext, string: []const u8,
         return suffix_matcher.match(string);
     }
 
-    return fnmatchCore(ctx.pattern, string, !flags.noescape);
+    return fnmatchCore(ctx.pattern, string, !flags.noescape, flags.pathname);
 }
 
-fn fnmatchCore(pattern: []const u8, string: []const u8, enable_escapes: bool) bool {
+fn fnmatchCore(pattern: []const u8, string: []const u8, enable_escapes: bool, enable_pathname: bool) bool {
     var pi: usize = 0;
     var si: usize = 0;
 
@@ -114,6 +114,7 @@ fn fnmatchCore(pattern: []const u8, string: []const u8, enable_escapes: bool) bo
                 }
                 // Fall through to star backtrack
                 if (have_star and star_si < string.len) {
+                    if (enable_pathname and string[star_si] == '/') return false;
                     pi = star_pi;
                     star_si += 1;
                     si = star_si;
@@ -128,24 +129,33 @@ fn fnmatchCore(pattern: []const u8, string: []const u8, enable_escapes: bool) bo
                     pi += 1;
                     while (pi < pattern.len and pattern[pi] == '*') pi += 1;
 
-                    // If star is at end of pattern, it matches everything
-                    if (pi >= pattern.len) return true;
+                    // If star is at end of pattern, it matches everything remaining —
+                    // unless PATHNAME is set, in which case '/' cannot be consumed.
+                    if (pi >= pattern.len) {
+                        if (enable_pathname) return mem.indexOfScalar(u8, string[si..], '/') == null;
+                        return true;
+                    }
 
                     // SIMD optimization: if the next pattern char after * is a literal,
                     // use simdFindChar to jump directly to candidate positions in the
                     // string instead of advancing one char at a time on each backtrack.
+                    // With PATHNAME the search is bounded to the next '/' so the star
+                    // never jumps across a path separator.
                     const next_pc = pattern[pi];
                     const next_is_literal = next_pc != '*' and next_pc != '?' and next_pc != '[' and
                         !(enable_escapes and next_pc == '\\');
                     if (next_is_literal) {
-                        // Find next occurrence of the literal char starting from si
-                        if (simdFindChar(string[si..], next_pc)) |offset| {
+                        const remaining = string[si..];
+                        const search_end = if (enable_pathname)
+                            (mem.indexOfScalar(u8, remaining, '/') orelse remaining.len)
+                        else
+                            remaining.len;
+                        if (simdFindChar(remaining[0..search_end], next_pc)) |offset| {
                             star_pi = pi;
                             star_si = si + offset; // will be incremented on backtrack
                             si = si + offset;
                             have_star = true;
                         } else {
-                            // Literal char not found anywhere — no match possible
                             return false;
                         }
                     } else {
@@ -157,7 +167,8 @@ fn fnmatchCore(pattern: []const u8, string: []const u8, enable_escapes: bool) bo
                     continue;
                 },
                 '?' => {
-                    if (si < string.len) {
+                    // With PATHNAME, '?' cannot match '/'.
+                    if (si < string.len and !(enable_pathname and string[si] == '/')) {
                         pi += 1;
                         si += 1;
                         continue;
@@ -186,17 +197,26 @@ fn fnmatchCore(pattern: []const u8, string: []const u8, enable_escapes: bool) bo
             }
         }
 
-        // Mismatch — try to backtrack to last star
+        // Mismatch — try to backtrack to last star.
+        // With PATHNAME, the star cannot consume a '/', so stop backtracking if
+        // the next character to be consumed would be a path separator.
         if (have_star and star_si < string.len) {
+            if (enable_pathname and string[star_si] == '/') return false;
             star_si += 1;
             // SIMD-accelerated backtrack: if the char after * is a literal,
-            // jump to its next occurrence instead of trying every position
+            // jump to its next occurrence instead of trying every position.
+            // With PATHNAME, bound the search to before the next '/'.
             if (star_pi < pattern.len) {
                 const next_pc = pattern[star_pi];
                 const next_is_literal = next_pc != '*' and next_pc != '?' and next_pc != '[' and
                     !(enable_escapes and next_pc == '\\');
                 if (next_is_literal) {
-                    if (simdFindChar(string[star_si..], next_pc)) |offset| {
+                    const remaining = string[star_si..];
+                    const search_end = if (enable_pathname)
+                        (mem.indexOfScalar(u8, remaining, '/') orelse remaining.len)
+                    else
+                        remaining.len;
+                    if (simdFindChar(remaining[0..search_end], next_pc)) |offset| {
                         star_si += offset;
                     } else {
                         return false;
@@ -749,7 +769,7 @@ fn matchPlusInner(alternatives: []const []const u8, rest_pattern: []const u8, st
         var end_pos = str_pos;
         while (end_pos <= string.len) : (end_pos += 1) {
             const candidate = string[str_pos..end_pos];
-            if (fnmatchCore(alt, candidate, true)) {
+            if (fnmatchCore(alt, candidate, true, false)) {
                 if (matchExtglobImpl(rest_pattern, string, 0, end_pos)) return true;
                 if (end_pos > str_pos) {
                     if (matchPlusInner(alternatives, rest_pattern, string, end_pos, visited)) return true;
@@ -768,7 +788,7 @@ fn matchNot(alternatives: []const []const u8, rest_pattern: []const u8, string: 
 
         var matches_any = false;
         for (alternatives) |alt| {
-            if (fnmatchCore(alt, candidate, true)) {
+            if (fnmatchCore(alt, candidate, true, false)) {
                 matches_any = true;
                 break;
             }
@@ -786,7 +806,7 @@ fn tryMatchAlternative(alt: []const u8, rest_pattern: []const u8, string: []cons
     var end_pos = str_pos;
     while (end_pos <= string.len) : (end_pos += 1) {
         const candidate = string[str_pos..end_pos];
-        if (fnmatchCore(alt, candidate, true)) {
+        if (fnmatchCore(alt, candidate, true, false)) {
             if (matchExtglobImpl(rest_pattern, string, 0, end_pos)) return true;
         }
     }
@@ -826,10 +846,10 @@ test "fnmatch - empty patterns" {
 }
 
 test "fnmatchCore - iterative star does not overflow stack" {
-    try std.testing.expect(fnmatchCore("*.rs", "hello.rs", true));
-    try std.testing.expect(!fnmatchCore("*.rs", "hello.txt", true));
-    try std.testing.expect(fnmatchCore("a*b*c*d", "aXbYcZd", true));
-    try std.testing.expect(!fnmatchCore("a*b*c*d", "aXbYcZ", true));
+    try std.testing.expect(fnmatchCore("*.rs", "hello.rs", true, false));
+    try std.testing.expect(!fnmatchCore("*.rs", "hello.txt", true, false));
+    try std.testing.expect(fnmatchCore("a*b*c*d", "aXbYcZd", true, false));
+    try std.testing.expect(!fnmatchCore("a*b*c*d", "aXbYcZ", true, false));
 }
 
 test "detectExtglobAt - basic detection" {

--- a/src/gitignore.zig
+++ b/src/gitignore.zig
@@ -380,7 +380,7 @@ pub const GitIgnore = struct {
                 }
                 return false;
             }
-            return path_matcher.matchGlobSimple(text, path);
+            return path_matcher.matchGlobSimple(text, path, .{});
         }
 
         // Non-anchored patterns without / match against basename only
@@ -423,14 +423,14 @@ pub const GitIgnore = struct {
         // Non-anchored patterns with / - match full path
         // For directory patterns, also match paths inside the directory
         if (pattern.dir_only) {
-            if (path_matcher.matchGlobSimple(text, path)) return true;
+            if (path_matcher.matchGlobSimple(text, path, .{})) return true;
             // Check if any path component matches and this is a child path
             // e.g., pattern "target" with dir_only should match "foo/target/bar.rs"
             var start: usize = 0;
             while (start < path.len) {
                 const end = mem.indexOfPos(u8, path, start, "/") orelse path.len;
                 const component_path = path[0..end];
-                if (path_matcher.matchGlobSimple(text, component_path)) {
+                if (path_matcher.matchGlobSimple(text, component_path, .{})) {
                     // This path component matches, so any path starting with it is inside
                     return true;
                 }
@@ -439,7 +439,7 @@ pub const GitIgnore = struct {
             }
             return false;
         }
-        return path_matcher.matchGlobSimple(text, path);
+        return path_matcher.matchGlobSimple(text, path, .{});
     }
 
     /// Check if a directory should be skipped entirely (not traversed)

--- a/src/path_matcher.zig
+++ b/src/path_matcher.zig
@@ -20,9 +20,9 @@ const splitPathComponentsNormalized = compiled_pattern.splitPathComponentsNormal
 /// - `?` matches exactly one character except `/`
 /// - `[abc]` matches one character from the set
 /// - `**` matches zero or more directories
-pub fn matchGlobSimple(pattern: []const u8, path: []const u8) bool {
+pub fn matchGlobSimple(pattern: []const u8, path: []const u8, flags: glob.ZlobFlags) bool {
     if (mem.indexOf(u8, pattern, "**") == null) {
-        return fnmatch_mod.fnmatch(pattern, path, .{});
+        return fnmatch_mod.fnmatch(pattern, path, flags);
     }
 
     var pat_segments_buf: [32][]const u8 = undefined;

--- a/test/test_fnmatch.zig
+++ b/test/test_fnmatch.zig
@@ -617,3 +617,55 @@ test "fnmatch - noescape flag treats backslash as literal" {
     try testing.expect(!fnmatch.fnmatch("\\*", "*", noescape));
     try testing.expect(fnmatch.fnmatch("\\*", "\\anything", noescape));
 }
+
+// ============================================================================
+// PATHNAME flag tests (like POSIX FNM_PATHNAME: * and ? stop at /)
+// ============================================================================
+
+const pathname_flags = zlob.ZlobFlags{ .pathname = true };
+
+test "fnmatch pathname - * does not match /" {
+    // Without PATHNAME, * crosses /
+    try testing.expect(fnmatch.fnmatch("*", "a/b", .{}));
+    try testing.expect(fnmatch.fnmatch("docs/*", "docs/api/index.md", .{}));
+
+    // With PATHNAME, * stops at /
+    try testing.expect(fnmatch.fnmatch("*", "a", pathname_flags));
+    try testing.expect(!fnmatch.fnmatch("*", "a/b", pathname_flags));
+}
+
+test "fnmatch pathname - * at end of pattern stops at /" {
+    try testing.expect(fnmatch.fnmatch("docs/*", "docs/index.md", pathname_flags));
+    try testing.expect(!fnmatch.fnmatch("docs/*", "docs/api/index.md", pathname_flags));
+    try testing.expect(!fnmatch.fnmatch("docs/*", "docs/api/deep/index.md", pathname_flags));
+}
+
+test "fnmatch pathname - *.ext pattern stops at /" {
+    try testing.expect(fnmatch.fnmatch("docs/*.md", "docs/index.md", pathname_flags));
+    try testing.expect(!fnmatch.fnmatch("docs/*.md", "docs/api/index.md", pathname_flags));
+}
+
+test "fnmatch pathname - ? does not match /" {
+    // Without PATHNAME, ? matches any single char including /
+    try testing.expect(fnmatch.fnmatch("a?b", "a/b", .{}));
+
+    // With PATHNAME, ? refuses to match /
+    try testing.expect(!fnmatch.fnmatch("a?b", "a/b", pathname_flags));
+    try testing.expect(fnmatch.fnmatch("a?b", "axb", pathname_flags));
+}
+
+test "fnmatch pathname - literal / in pattern still matches" {
+    // Explicit / in pattern always matches /
+    try testing.expect(fnmatch.fnmatch("docs/index.md", "docs/index.md", pathname_flags));
+    try testing.expect(!fnmatch.fnmatch("docs/index.md", "docs/other.md", pathname_flags));
+}
+
+test "fnmatch pathname - /anchored/pattern/* matches one level only" {
+    try testing.expect(fnmatch.fnmatch("/docs/*", "/docs/index.md", pathname_flags));
+    try testing.expect(!fnmatch.fnmatch("/docs/*", "/docs/api/index.md", pathname_flags));
+}
+
+test "fnmatch pathname - star matches empty segment" {
+    // * should still match zero characters (empty filename component)
+    try testing.expect(fnmatch.fnmatch("docs/*", "docs/", pathname_flags));
+}


### PR DESCRIPTION
## Problem

Without a way to restrict `*` to a single path segment, patterns like `docs/*` unexpectedly match arbitrarily deep paths (e.g. `docs/api/index.md`). This is because when a pattern has no `**`, zlob's `fnmatchCore` matches the full path string directly and treats `/` as an ordinary character.

POSIX `fnmatch` solves this with `FNM_PATHNAME`. zlob had no equivalent.

## Solution

Add `ZLOB_PATHNAME` (bit 27) which makes `*` and `?` stop at `/`:

- `*` at end of pattern: returns false if any `/` remains in the unmatched string
- `*` mid-pattern: SIMD search for the next literal is bounded to before the next `/`
- `*` backtracking: stops as soon as it would consume a `/`
- `?`: refuses to match `/`

The flag only affects the no-`**` code path in `fnmatchCore`. When `DOUBLESTAR_RECURSIVE` is set and the pattern contains `**`, segment-by-segment matching already provides this behaviour implicitly — `PATHNAME` is a no-op in that case.

## Changes

- `include/zlob.h` — define `ZLOB_PATHNAME = 1 << 27`
- `src/flags.zig` — add `pathname` field to `ZlobFlags` packed struct
- `src/fnmatch.zig` — thread `enable_pathname` into `fnmatchCore`; gate `*` and `?` at `/`
- `src/compiled_pattern.zig` — pass `flags.pathname` through in `matchSinglePath` for the no-doublestar branch
- `src/path_matcher.zig` — add `ZlobFlags` parameter to `matchGlobSimple`
- `src/gitignore.zig` — update `matchGlobSimple` call sites (pass `.{}`, no behaviour change)
- `rust/src/flags.rs` — expose `PATHNAME` in the Rust `ZlobFlags` bitflags
- `test/test_fnmatch.zig` — add `PATHNAME` test cases

## Example

```zig
const pat = ZlobFlags{ .pathname = true };
try std.testing.expect(fnmatch.fnmatch("docs/*", "docs/index.md", pat));      // true
try std.testing.expect(!fnmatch.fnmatch("docs/*", "docs/api/index.md", pat)); // false — was true before
```

```rust
let flags = ZlobFlags::PATHNAME;
let pat = ZlobPattern::compile("docs/*", flags).unwrap();
assert!(pat.matches("docs/index.md", flags));
assert!(!pat.matches("docs/api/index.md", flags));
```