### PR TITLE
fix: preserve Git ignore precedence in walker

### DIFF
--- a/include/zlob.h
+++ b/include/zlob.h
@@ -467,6 +467,14 @@ void *zlob_walk_result_ignore_rules(const zlob_walk_result_t *result);
  */
 int zlob_ignore_rules_match_path(void *rules, const char *path);
 
+/**
+ * Match a root-relative candidate without requiring it to exist.
+ * `is_dir` controls directory-only ignore patterns. Absolute paths, empty
+ * paths, and paths containing `.` or `..` components fail closed.
+ * Returns 1 when ignored (or invalid), 0 when accepted.
+ */
+int zlob_ignore_rules_match_candidate(void *rules, const char *relative_path, uint8_t is_dir);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zlob.h
+++ b/include/zlob.h
@@ -377,6 +377,9 @@ typedef struct zlob_walk_options {
   /* ZLOB_* flags used to compile/match `pattern`.
    * 0 = default (ZLOB_BRACE | ZLOB_DOUBLESTAR_RECURSIVE). */
   uint32_t pattern_flags;
+  /* Caller-supplied root-relative ignore document with lower precedence than
+   * every discovered .gitignore/.ignore. NULL = disabled. */
+  const char *base_ignore;
   /* Caller-supplied .gitignore document layered into the walker, one rule
    * per line, NUL-terminated. NULL = disabled. Surfaces as the *deepest*
    * node in the gitignore chain, so its `!negation` rules win over project

--- a/rust/src/ffi_stub.rs
+++ b/rust/src/ffi_stub.rs
@@ -302,4 +302,10 @@ unsafe extern "C" {
         rules: *mut core::ffi::c_void,
         path: *const c_char,
     ) -> c_int;
+
+    pub fn zlob_ignore_rules_match_candidate(
+        rules: *mut core::ffi::c_void,
+        relative_path: *const c_char,
+        is_dir: u8,
+    ) -> c_int;
 }

--- a/rust/src/walk.rs
+++ b/rust/src/walk.rs
@@ -118,6 +118,7 @@ pub enum WalkEntryKind {
 /// Builder for a parallel directory walk. Settings diefault to [`WalkFlags::RECOMMENDED`]
 #[derive(Debug, Clone)]
 pub struct WalkBuilder {
+    base_ignore: Option<CString>,
     extra_ignore: Option<CString>,
     flags: WalkFlags,
     max_depth: u16,
@@ -139,6 +140,7 @@ impl WalkBuilder {
             max_depth: 0,
             pattern_flags: 0,
             pattern: None,
+            base_ignore: None,
             extra_ignore: None,
         })
     }
@@ -215,6 +217,18 @@ impl WalkBuilder {
         Ok(self)
     }
 
+    /// Root-relative ignore rules below every discovered ignore file.
+    pub fn base_ignore<S: AsRef<str>>(&mut self, patterns: &[S]) -> Result<&mut Self> {
+        let mut joined = String::new();
+        for p in patterns {
+            joined.push_str(p.as_ref());
+            joined.push('\n');
+        }
+
+        self.base_ignore = Some(CString::new(joined).map_err(|_| ZlobError::InvalidInput)?);
+        Ok(self)
+    }
+
     /// Number of worker threads. `0` (default) = one per CPU; `1` = run on the calling thread.
     pub fn threads(&mut self, n: usize) -> &mut Self {
         self.threads = n.min(u16::MAX as usize) as u16;
@@ -268,6 +282,10 @@ impl WalkBuilder {
             Some(p) => p.as_ptr(),
             None => std::ptr::null(),
         };
+        let base_ignore = match self.base_ignore.as_ref() {
+            Some(p) => p.as_ptr(),
+            None => std::ptr::null(),
+        };
 
         Ok((
             root,
@@ -279,6 +297,7 @@ impl WalkBuilder {
                 errfunc: None,
                 pattern,
                 pattern_flags: self.pattern_flags as u32,
+                base_ignore,
                 extra_ignore,
             },
         ))
@@ -1078,6 +1097,80 @@ mod tests {
         assert!(rules.is_ignored("drop.rs"));
         assert!(!rules.is_ignored("src/important/special.rs"));
         assert!(rules.is_ignored("src/main.rs"));
+    }
+
+    #[test]
+    fn nested_directory_negation_prevents_pruning() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join(".gitignore"), "*\n!*.*\n!/**/\n").unwrap();
+        fs::create_dir_all(root.join("sub1/sub2")).unwrap();
+        fs::write(root.join("top.rs"), "").unwrap();
+        fs::write(root.join("sub1/mid.rs"), "").unwrap();
+        fs::write(root.join("sub1/sub2/deep.rs"), "").unwrap();
+
+        let results = WalkBuilder::new(root).unwrap().collect().unwrap();
+        let names: Vec<_> = results
+            .iter()
+            .filter(|entry| entry.is_file())
+            .map(|entry| entry.relative_path().to_string_lossy().into_owned())
+            .collect();
+
+        assert!(names.contains(&"top.rs".to_string()), "got {names:?}");
+        assert!(names.contains(&"sub1/mid.rs".to_string()), "got {names:?}");
+        assert!(
+            names.contains(&"sub1/sub2/deep.rs".to_string()),
+            "got {names:?}"
+        );
+    }
+
+    #[test]
+    fn base_ignore_has_lower_precedence_than_discovered_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join(".gitignore"), "!root-keep.log\n").unwrap();
+        fs::create_dir(root.join("nested")).unwrap();
+        fs::write(root.join("nested/.gitignore"), "!nested-keep.log\n").unwrap();
+        for path in [
+            "drop.log",
+            "root-keep.log",
+            "nested/drop.log",
+            "nested/nested-keep.log",
+        ] {
+            fs::write(root.join(path), "").unwrap();
+        }
+
+        let results = WalkBuilder::new(root)
+            .unwrap()
+            .base_ignore(&["*.log"])
+            .unwrap()
+            .collect()
+            .unwrap();
+        let names: Vec<_> = results
+            .iter()
+            .filter(|entry| entry.is_file())
+            .map(|entry| entry.relative_path().to_string_lossy().into_owned())
+            .collect();
+
+        assert!(!names.contains(&"drop.log".to_string()), "got {names:?}");
+        assert!(
+            names.contains(&"root-keep.log".to_string()),
+            "got {names:?}"
+        );
+        assert!(
+            !names.contains(&"nested/drop.log".to_string()),
+            "got {names:?}"
+        );
+        assert!(
+            names.contains(&"nested/nested-keep.log".to_string()),
+            "got {names:?}"
+        );
+
+        let rules = results.ignore_rules().expect("base ignore retains rules");
+        assert!(rules.is_ignored("drop.log"));
+        assert!(!rules.is_ignored("root-keep.log"));
+        assert!(rules.is_ignored("nested/drop.log"));
+        assert!(!rules.is_ignored("nested/nested-keep.log"));
     }
 
     #[test]

--- a/rust/src/walk.rs
+++ b/rust/src/walk.rs
@@ -446,6 +446,18 @@ impl IgnoreRules<'_> {
         };
         unsafe { ffi::zlob_ignore_rules_match_path(self.handle, cpath.as_ptr()) != 0 }
     }
+
+    /// Match a root-relative candidate without requiring it to exist.
+    /// `is_dir` controls directory-only patterns; invalid paths fail closed.
+    pub fn is_ignored_candidate(&self, relative_path: impl AsRef<Path>, is_dir: bool) -> bool {
+        let Ok(cpath) = CString::new(path_to_bytes(relative_path.as_ref())) else {
+            return true;
+        };
+        unsafe {
+            ffi::zlob_ignore_rules_match_candidate(self.handle, cpath.as_ptr(), u8::from(is_dir))
+                != 0
+        }
+    }
 }
 
 /// Owned results of [`WalkBuilder::collect`]. Holds all paths and metadata in
@@ -1330,6 +1342,39 @@ mod tests {
         // Sanity: non-ignored path from a visited subtree.
         assert!(!rules.is_ignored("src/main.rs"));
         assert!(!rules.is_ignored("src/lib.rs"));
+    }
+
+    #[test]
+    fn candidate_matcher_reuses_all_layers_without_lstat() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir(root.join("notes")).unwrap();
+        fs::write(root.join(".gitignore"), "*.root\nbuild/\n!keep.root\n").unwrap();
+        fs::write(root.join("notes/.gitignore"), "*.tmp\n!keep.tmp\n").unwrap();
+
+        let results = WalkBuilder::new(root)
+            .unwrap()
+            .base_ignore(&["*.global"])
+            .unwrap()
+            .extra_ignore(&["node_modules"])
+            .unwrap()
+            .collect()
+            .unwrap();
+        let rules = results.ignore_rules().expect("rules retained");
+
+        assert!(rules.is_ignored_candidate("future.global", false));
+        assert!(rules.is_ignored_candidate("future.root", false));
+        assert!(!rules.is_ignored_candidate("keep.root", false));
+        assert!(rules.is_ignored_candidate("notes/future.tmp", false));
+        assert!(!rules.is_ignored_candidate("notes/keep.tmp", false));
+        assert!(rules.is_ignored_candidate("node_modules/pkg/index.js", false));
+        assert!(rules.is_ignored_candidate("build", true));
+        assert!(!rules.is_ignored_candidate("build", false));
+        assert!(rules.is_ignored_candidate("", true));
+        assert!(rules.is_ignored_candidate("./future.md", false));
+        assert!(!rules.is_ignored(root));
+        assert!(!rules.is_ignored(""));
+        assert!(!root.join("future.root").exists());
     }
 
     #[test]

--- a/src/c_lib.zig
+++ b/src/c_lib.zig
@@ -1004,3 +1004,12 @@ pub export fn zlob_ignore_rules_match_path(
     const r: *const walk.IgnoreRules = @ptrCast(@alignCast(rules orelse return 0));
     return @intFromBool(r.isIgnoredPath(mem.sliceTo(path, 0)));
 }
+
+pub export fn zlob_ignore_rules_match_candidate(
+    rules: ?*anyopaque,
+    relative_path: [*:0]const u8,
+    is_dir: u8,
+) c_int {
+    const r: *const walk.IgnoreRules = @ptrCast(@alignCast(rules orelse return 1));
+    return @intFromBool(r.isIgnoredCandidate(mem.sliceTo(relative_path, 0), is_dir != 0));
+}

--- a/src/c_lib.zig
+++ b/src/c_lib.zig
@@ -742,6 +742,8 @@ pub const zlob_walk_options_t = extern struct {
     errfunc: zlob_walk_errfunc_t = null,
     pattern: ?[*:0]const u8 = null,
     pattern_flags: u32 = 0,
+    /// Lowest-precedence root-relative ignore document. NULL = disabled.
+    base_ignore: ?[*:0]const u8 = null,
     /// Caller-supplied .gitignore document layered as the deepest node in the
     /// chain so its `!negation` rules win over project `.gitignore`. One rule
     /// per line, NUL-terminated. NULL = disabled.
@@ -810,6 +812,7 @@ fn walkOptionsFromC(options: ?*const zlob_walk_options_t) walk.Options {
             ZlobFlags.fromU32(v.pattern_flags)
         else
             .{ .brace = true, .doublestar_recursive = true },
+        .base_ignore = if (v.base_ignore) |p| mem.sliceTo(p, 0) else null,
         .extra_ignore = if (v.extra_ignore) |p| mem.sliceTo(p, 0) else null,
         .meta = walk.MetaMask.fromInt(v.meta_mask),
         .sort = f & ZLOB_WALK_SORT != 0,

--- a/src/gitignore.zig
+++ b/src/gitignore.zig
@@ -659,6 +659,12 @@ pub const GitIgnore = struct {
             // For directory patterns, also match paths that are inside the directory
             // e.g., pattern "rust/target" should match "rust/target/debug/foo.rs"
             if (pattern.dir_only) {
+                if (pattern.segments.len > 0) {
+                    if (path_segments) |ps| {
+                        return path_matcher.matchGlobSimplePresplitAnyPrefixWithPath(pattern.segments, ps);
+                    }
+                    return path_matcher.matchGlobSimplePresplitAnyPrefix(pattern.segments, path);
+                }
                 // Check exact match first
                 if (mem.eql(u8, text, path)) return true;
                 // Check if path is inside this directory (path starts with "pattern/")

--- a/src/walker/ignore_rules.zig
+++ b/src/walker/ignore_rules.zig
@@ -12,6 +12,7 @@ const MAX_DIR_CHAIN = 64;
 pub const IgnoreRules = struct {
     allocator: std.mem.Allocator,
     by_dir: std.StringHashMapUnmanaged(*IgnoreNode) = .empty,
+    base: ?*IgnoreNode = null,
     extra: ?*IgnoreNode = null,
     walk_root: []const u8 = &.{},
 
@@ -127,45 +128,13 @@ pub const IgnoreRules = struct {
             else
                 ancestor;
 
-            if (self.extra) |x| {
-                if (x.gi.checkWithBasename(ancestor, ancestor_basename, true)) |v| {
-                    if (v) return true;
-                }
-            }
-            for (chain[0..chain_len]) |node| {
-                // A node only has scope over `ancestor` when its directory is
-                // an ancestor-or-equal of it, i.e. `relative_offset` fits.
-                if (node.relative_offset > ancestor.len) continue;
-                if (node.gi.checkWithBasename(
-                    ancestor[node.relative_offset..],
-                    ancestor_basename,
-                    true,
-                )) |v| {
-                    if (v) return true;
-                }
-            }
+            if (resolveChain(self, chain[0..chain_len], ancestor, ancestor_basename, true) == true)
+                return true;
             offset = slash + 1;
         }
 
         // now we have to check every single node in the chain as git would do it
-        if (self.extra) |x| {
-            if (x.gi.checkWithBasename(normalized, basename, is_dir)) |verdict| {
-                return verdict;
-            }
-        }
-        var i: usize = chain_len;
-        while (i > 0) {
-            i -= 1;
-            const node = chain[i];
-            if (node.gi.checkWithBasename(
-                normalized[node.relative_offset..],
-                basename,
-                is_dir,
-            )) |verdict| {
-                return verdict;
-            }
-        }
-        return false;
+        return resolveChain(self, chain[0..chain_len], normalized, basename, is_dir) orelse false;
     }
 
     fn isIgnoredPathSlow(
@@ -182,61 +151,36 @@ pub const IgnoreRules = struct {
             else
                 ancestor;
 
-            if (self.extra) |x| {
-                if (x.gi.checkWithBasename(ancestor, ancestor_basename, true)) |v| {
-                    if (v) return true;
-                }
-            }
-            if (self.by_dir.get("")) |node| {
-                if (node.gi.checkWithBasename(ancestor, ancestor_basename, true)) |v| {
-                    if (v) return true;
-                }
-            }
-            var mid_off: usize = 0;
-            while (mem.indexOfScalarPos(u8, ancestor, mid_off, '/')) |mid_slash| {
-                const mid_dir = ancestor[0..mid_slash];
-                if (self.by_dir.get(mid_dir)) |node| {
-                    if (node.gi.checkWithBasename(
-                        ancestor[node.relative_offset..],
-                        ancestor_basename,
-                        true,
-                    )) |v| {
-                        if (v) return true;
-                    }
-                }
-                mid_off = mid_slash + 1;
-            }
+            if (self.resolveSlowVerdict(ancestor, ancestor_basename, true) == true) return true;
             off = slash + 1;
         }
+        return self.resolveSlowVerdict(norm, basename, is_dir) orelse false;
+    }
 
-        if (self.extra) |x| {
-            if (x.gi.checkWithBasename(norm, basename, is_dir)) |verdict| {
-                return verdict;
-            }
+    fn resolveSlowVerdict(
+        self: *const IgnoreRules,
+        norm: []const u8,
+        basename: []const u8,
+        is_dir: bool,
+    ) ?bool {
+        if (self.extra) |node| {
+            if (node.gi.checkWithBasename(norm, basename, is_dir)) |verdict| return verdict;
         }
-
-        // Leaf resolution, deepest -> shallowest. Walk directory prefixes
-        // from the deepest slash back toward the root, then the root ruleset.
         var end: usize = norm.len;
         while (mem.lastIndexOfScalar(u8, norm[0..end], '/')) |slash| {
-            const dir = norm[0..slash];
-            if (self.by_dir.get(dir)) |node| {
-                if (node.gi.checkWithBasename(
-                    norm[node.relative_offset..],
-                    basename,
-                    is_dir,
-                )) |verdict| {
+            if (self.by_dir.get(norm[0..slash])) |node| {
+                if (node.gi.checkWithBasename(norm[node.relative_offset..], basename, is_dir)) |verdict|
                     return verdict;
-                }
             }
             end = slash;
         }
         if (self.by_dir.get("")) |node| {
-            if (node.gi.checkWithBasename(norm, basename, is_dir)) |verdict| {
-                return verdict;
-            }
+            if (node.gi.checkWithBasename(norm, basename, is_dir)) |verdict| return verdict;
         }
-        return false;
+        if (self.base) |node| {
+            if (node.gi.checkWithBasename(norm, basename, is_dir)) |verdict| return verdict;
+        }
+        return null;
     }
 
     pub fn isIgnoredInode(
@@ -278,6 +222,12 @@ pub const IgnoreRules = struct {
         if (node) |n| n.retain();
     }
 
+    pub fn setBase(self: *IgnoreRules, node: ?*IgnoreNode) void {
+        if (self.base) |old| old.release(self.allocator);
+        self.base = node;
+        if (node) |n| n.retain();
+    }
+
     pub fn setWalkRoot(self: *IgnoreRules, root: []const u8) !void {
         if (self.walk_root.len > 0) self.allocator.free(self.walk_root);
         self.walk_root = if (root.len == 0) &.{} else try self.allocator.dupe(u8, root);
@@ -288,6 +238,8 @@ pub const IgnoreRules = struct {
         self.walk_root = &.{};
         if (self.extra) |x| x.release(self.allocator);
         self.extra = null;
+        if (self.base) |x| x.release(self.allocator);
+        self.base = null;
         var it = self.by_dir.iterator();
         while (it.next()) |e| {
             self.allocator.free(e.key_ptr.*);
@@ -296,6 +248,30 @@ pub const IgnoreRules = struct {
         self.by_dir.deinit(self.allocator);
     }
 };
+
+fn resolveChain(
+    rules: *const IgnoreRules,
+    chain: []const *IgnoreNode,
+    norm: []const u8,
+    basename: []const u8,
+    is_dir: bool,
+) ?bool {
+    if (rules.extra) |node| {
+        if (node.gi.checkWithBasename(norm, basename, is_dir)) |verdict| return verdict;
+    }
+    var i = chain.len;
+    while (i > 0) {
+        i -= 1;
+        const node = chain[i];
+        if (node.relative_offset > norm.len) continue;
+        if (node.gi.checkWithBasename(norm[node.relative_offset..], basename, is_dir)) |verdict|
+            return verdict;
+    }
+    if (rules.base) |node| {
+        if (node.gi.checkWithBasename(norm, basename, is_dir)) |verdict| return verdict;
+    }
+    return null;
+}
 
 fn stripRootPrefix(root: []const u8, path: []const u8) ?[]const u8 {
     if (root.len == 0) return path;

--- a/src/walker/ignore_rules.zig
+++ b/src/walker/ignore_rules.zig
@@ -70,9 +70,30 @@ pub const IgnoreRules = struct {
 
         // ignore if the path is unreachable
         const is_dir = lstatIsDir(abs_z) orelse return true;
+        if (relative.len == 0) return false;
+        return self.isIgnoredCandidate(relative, is_dir);
+    }
 
-        const basename = if (mem.lastIndexOfScalar(u8, relative, '/')) |p| relative[p + 1 ..] else relative;
-        return self.isIgnoredResolved(relative, basename, is_dir);
+    /// Match a root-relative candidate without touching the filesystem.
+    pub fn isIgnoredCandidate(self: *const IgnoreRules, path: []const u8, is_dir: bool) bool {
+        var normalized_buffer: [MAX_PATH]u8 = undefined;
+        const normalized: []const u8 = if (mem.indexOfScalar(u8, path, '\\')) |_| blk: {
+            if (path.len > normalized_buffer.len) return true;
+            @memcpy(normalized_buffer[0..path.len], path);
+            for (normalized_buffer[0..path.len]) |*b| {
+                if (b.* == '\\') b.* = '/';
+            }
+            break :blk normalized_buffer[0..path.len];
+        } else path;
+        if (normalized.len == 0 or std.fs.path.isAbsolute(normalized)) return true;
+        var components = mem.splitScalar(u8, normalized, '/');
+        while (components.next()) |component| {
+            if (component.len == 0 or mem.eql(u8, component, ".") or mem.eql(u8, component, ".."))
+                return true;
+        }
+
+        const basename = if (mem.lastIndexOfScalar(u8, normalized, '/')) |p| normalized[p + 1 ..] else normalized;
+        return self.isIgnoredResolved(normalized, basename, is_dir);
     }
 
     fn isIgnoredResolved(
@@ -383,6 +404,42 @@ test "isIgnoredResolved: nested rules, ancestor pruning, negation, fast==slow" {
         try expectFastEqualsSlow(&rules, c, false);
         try expectFastEqualsSlow(&rules, c, true);
     }
+}
+
+test "isIgnoredCandidate: matches nonexistent files without lstat" {
+    const alloc = testing.allocator;
+    var rules: IgnoreRules = .{ .allocator = alloc };
+    defer rules.deinit();
+
+    try rules.put("", try testNode(alloc, "", "*.log\nbuild/\n!keep.log\n"));
+    (rules.by_dir.get("").?).release(alloc);
+    try rules.put("notes", try testNode(alloc, "notes", "*.tmp\n!keep.tmp\n"));
+    (rules.by_dir.get("notes").?).release(alloc);
+
+    try testing.expect(rules.isIgnoredCandidate("future.log", false));
+    try testing.expect(!rules.isIgnoredCandidate("keep.log", false));
+    try testing.expect(rules.isIgnoredCandidate("build", true));
+    try testing.expect(!rules.isIgnoredCandidate("build", false));
+    try testing.expect(rules.isIgnoredCandidate("notes/future.tmp", false));
+    try testing.expect(!rules.isIgnoredCandidate("notes/keep.tmp", false));
+    try testing.expect(rules.isIgnoredCandidate("../outside.md", false));
+    try testing.expect(rules.isIgnoredCandidate("./future.md", false));
+    try testing.expect(rules.isIgnoredCandidate("", true));
+}
+
+test "isIgnoredPath: the verified walk root remains accepted" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(alloc, ".");
+    defer alloc.free(root);
+
+    var rules: IgnoreRules = .{ .allocator = alloc };
+    defer rules.deinit();
+    try rules.setWalkRoot(root);
+
+    try testing.expect(!rules.isIgnoredPath(root));
+    try testing.expect(!rules.isIgnoredPath(""));
 }
 
 test "isIgnoredResolved: overflow beyond MAX_DIR_CHAIN falls back and matches" {

--- a/src/walker/types.zig
+++ b/src/walker/types.zig
@@ -213,6 +213,9 @@ pub const Options = struct {
     pattern: ?[]const u8 = null,
     /// Flags for compiling/matching `pattern`. Default: brace + recursive `**`.
     pattern_flags: ZlobFlags = .{ .brace = true, .doublestar_recursive = true },
+    /// Root-relative ignore document below every discovered ignore file.
+    /// Later sources keep normal Git precedence over this baseline.
+    base_ignore: ?[]const u8 = null,
     /// Extra ignore document layered into the walker, `.gitignore` syntax,
     /// one rule per line. Callers building from Rust use
     /// `WalkBuilder::extra_ignore(&["a", "b"])` which joins for them; direct

--- a/src/walker/walker.zig
+++ b/src/walker/walker.zig
@@ -189,13 +189,17 @@ fn walkImpl(
     }
     defer if (compiled) |*c| c.deinit();
 
+    const base_root = try buildIgnoreRoot(allocator, options.base_ignore);
+    defer if (base_root) |root_node| root_node.release(allocator);
+    if (base_root) |x| ignore_rules.setBase(x);
+
     // Extra-ignore root: caller-supplied patterns turned into a synthetic
     // .gitignore. `chainIgnored` checks it FIRST (deepest), so `!negation`
     // rules override the project's discovered .gitignore — same precedence a
     // deeper nested .gitignore would have. The walker holds one ref; the
     // IgnoreRules surface holds another so post-walk `isIgnored` matches the
     // same source set the walk used.
-    const extra_root = try buildExtraIgnoreRoot(allocator, options.extra_ignore);
+    const extra_root = try buildIgnoreRoot(allocator, options.extra_ignore);
     defer if (extra_root) |root_node| root_node.release(allocator);
     if (extra_root) |x| ignore_rules.setExtra(x);
 
@@ -246,8 +250,13 @@ fn walkImpl(
     sh.workers = workers;
     sh.threads = threads;
 
-    const root_task = try allocator.create(DirTask);
-    root_task.* = .{ .rel = try allocator.dupe(u8, ""), .depth = 0, .ignore = null, .parent = null };
+    const root_rel = try allocator.dupe(u8, "");
+    const root_task = allocator.create(DirTask) catch |err| {
+        allocator.free(root_rel);
+        return err;
+    };
+    if (base_root) |node| node.retain();
+    root_task.* = .{ .rel = root_rel, .depth = 0, .ignore = base_root, .parent = null };
     sh.queue.push(allocator, sh.io, 0, root_task) catch |err| {
         worker.freeTask(&sh, root_task);
         return err;
@@ -265,7 +274,7 @@ fn walkImpl(
 /// project-discovered rules. `doc` is a `.gitignore`-style document (one rule
 /// per line). Returns null on null/empty input. Refcount = 1; caller owns
 /// that ref and must `.release()` when done.
-fn buildExtraIgnoreRoot(allocator: Allocator, doc: ?[]const u8) WalkError!?*worker.IgnoreNode {
+fn buildIgnoreRoot(allocator: Allocator, doc: ?[]const u8) WalkError!?*worker.IgnoreNode {
     const content = doc orelse return null;
     if (content.len == 0) return null;
     var gi = try GitIgnore.parse(allocator, content);

--- a/test/test_posix.zig
+++ b/test/test_posix.zig
@@ -696,13 +696,19 @@ test "ZLOB_TILDE with recursive glob" {
     std.Io.Dir.cwd().createDir(io, test_dir_path, .default_dir) catch {};
     defer std.Io.Dir.cwd().deleteTree(io, test_dir_path) catch {};
 
-    const test_file = try std.fmt.allocPrint(allocator, "{s}/test.txt", .{test_dir_path});
+    const nested_dir = try std.fmt.allocPrint(allocator, "{s}/nested", .{test_dir_path});
+    defer allocator.free(nested_dir);
+    std.Io.Dir.cwd().createDir(io, nested_dir, .default_dir) catch {};
+
+    const test_file = try std.fmt.allocPrint(allocator, "{s}/test.txt", .{nested_dir});
     defer allocator.free(test_file);
 
     var f = std.Io.Dir.cwd().createFile(io, test_file, .{}) catch return error.SkipZigTest;
     f.close(io);
 
-    const pattern = try allocator.dupeZ(u8, "~/**/.zlob_test_nested/*.txt");
+    // Keep the recursive walk inside the fixture. Scanning ~/** made this test
+    // depend on the size and accessibility of the developer's entire home.
+    const pattern = try allocator.dupeZ(u8, "~/.zlob_test_nested/**/*.txt");
     defer allocator.free(pattern);
 
     var pzlob: glob.zlob_t = undefined;


### PR DESCRIPTION
## Summary

- add a lowest-precedence `base_ignore` layer for host-supplied Git policy
- preserve discovered root/nested ignore precedence and reusable matcher parity
- prevent pruning directories that may be re-included by nested negation (`!/**/`)
- keep the tilde + doublestar test inside its fixture instead of recursively scanning the developer home

This is the zlob half of dmtrKovalenko/fff#723 and the global/info-exclude parity work.

## Verification

- `zig build test --summary all`: 509/509
- `cargo test --manifest-path rust/Cargo.toml`: 85 unit, repository E2E, 31 doctests