### PR TITLE
perf: getdents64 DirIterator, single-buffer results, SWAR dirent scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install clang-format
+        run: pipx install "clang-format==$(make print-clang-format-version)"
+
       - name: Check format
         run: make format-check
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,16 @@ LIBNAME = libzlob.so
 
 ZIG = zig
 CC ?= gcc
-CFLAGS = -Wall -Wextra -O2
+CFLAGS = -Wall -Wextra -O3
 CARGO ?= cargo
 CLANG_FORMAT ?= clang-format
+CLANG_FORMAT_VERSION = 22.1.5
 
 C_FORMAT_FILES = include/zlob.h test/test_c_api.c test/test_nolibc_threads.c
+
+# Every Zig path either target touches. build.zig(.zon) were previously
+# formatted by neither.
+ZIG_FORMAT_PATHS = src/ test/ bench/ build.zig build.zig.zon
 
 # Detect OS for library extension
 UNAME_S := $(shell uname -s)
@@ -25,7 +30,7 @@ else
     LIBEXT = dll
 endif
 
-.PHONY: all build install uninstall test clean cli install-cli uninstall-cli dev dev-test test-libc test-nolibc-threads format format-check help
+.PHONY: all build install uninstall test clean cli install-cli uninstall-cli dev dev-test test-libc test-nolibc-threads format format-check print-clang-format-version help
 
 all: build
 
@@ -180,15 +185,18 @@ test-libc: build
 	@echo "========================================"
 	./test/test_libc_comparison.sh
 
+print-clang-format-version:
+	@echo $(CLANG_FORMAT_VERSION)
+
 format:
-	zig fmt src/ test/ bench/
+	zig fmt $(ZIG_FORMAT_PATHS)
 	$(CLANG_FORMAT) -i $(C_FORMAT_FILES)
 	cd rust && cargo fmt --all
 
 format-check:
-	zig fmt --check src/ test/ bench/
+	zig fmt --check $(ZIG_FORMAT_PATHS)
 	$(CLANG_FORMAT) --dry-run --Werror $(C_FORMAT_FILES)
-	cd rust && cargo fmt --check
+	cd rust && cargo fmt --all --check
 
 help:
 	@echo "zlob - faster and more correct glob library, 100% POSIX compatible"

--- a/build.zig
+++ b/build.zig
@@ -271,6 +271,7 @@ pub fn build(b: *std.Build) void {
         "test/test_walk.zig",
         "test/test_walker_paths.zig",
         // files with inline tests
+        "src/walker.zig",
         "src/brace_optimizer.zig",
         "src/gitignore.zig",
         "src/fnmatch.zig",

--- a/build.zig
+++ b/build.zig
@@ -269,6 +269,7 @@ pub fn build(b: *std.Build) void {
         "test/test_edge_cases.zig",
         "test/test_absolute_paths.zig",
         "test/test_walk.zig",
+        "test/test_walker_paths.zig",
         // files with inline tests
         "src/brace_optimizer.zig",
         "src/gitignore.zig",

--- a/build.zig
+++ b/build.zig
@@ -81,11 +81,23 @@ pub fn build(b: *std.Build) void {
     // to our consumers. We must give it a name because a Zig package can expose
     // multiple modules and consumers will need to be able to specify which
     // module they want to access.
+    // Shared dirent-record helpers. Its own module because both walker.zig
+    // (module "walker") and walker/scan.zig (reached by path from zlob.zig)
+    // need it, and Zig requires every file to belong to exactly one module.
+    const dirent_mod = b.addModule("dirent", .{
+        .root_source_file = srcPath(b, src_dir, "walker/dirent.zig"),
+        .target = target,
+        .link_libc = use_libc,
+    });
+
     // Walker module (platform-optimized directory walker)
     const walker_mod = b.addModule("walker", .{
         .root_source_file = srcPath(b, src_dir, "walker.zig"),
         .target = target,
         .link_libc = use_libc,
+        .imports = &.{
+            .{ .name = "dirent", .module = dirent_mod },
+        },
     });
 
     // Flags module (canonical source of all ZLOB_* constants)
@@ -104,6 +116,7 @@ pub fn build(b: *std.Build) void {
         .imports = &.{
             .{ .name = "walker", .module = walker_mod },
             .{ .name = "zlob_flags", .module = flags_mod },
+            .{ .name = "dirent", .module = dirent_mod },
         },
     });
     // Add include path for C header imports (flags.zig uses @cImport)
@@ -291,6 +304,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "test_utils", .module = test_utils_mod },
                 .{ .name = "walker", .module = walker_mod },
                 .{ .name = "zlob_flags", .module = flags_mod },
+                .{ .name = "dirent", .module = dirent_mod },
             },
         });
         // Add include path for C header imports (flags.zig uses @cImport)

--- a/include/zlob.h
+++ b/include/zlob.h
@@ -330,23 +330,23 @@ int zlob_pattern_match_paths_indices_at_slice(const zlob_pattern_t *p,
 
 /** Metadata attribute bits for zlob_walk_options_t.meta_mask and
  *  zlob_walk_entry_t.meta_valid. */
-#define ZLOB_META_SIZE            (1u << 0)
-#define ZLOB_META_MTIME           (1u << 1)
-#define ZLOB_META_ATIME           (1u << 2)
-#define ZLOB_META_CTIME           (1u << 3)
-#define ZLOB_META_BTIME           (1u << 4) /* creation time (not on all filesystems) */
-#define ZLOB_META_INODE           (1u << 5)
-#define ZLOB_META_NLINK           (1u << 6)
-#define ZLOB_META_MODE            (1u << 7) /* permission bits (mode & 07777) */
-#define ZLOB_META_UID             (1u << 8)
-#define ZLOB_META_GID             (1u << 9)
-#define ZLOB_META_ALL             0x3FFu /* every attribute above (bits 0-9) */
+#define ZLOB_META_SIZE        (1u << 0)
+#define ZLOB_META_MTIME       (1u << 1)
+#define ZLOB_META_ATIME       (1u << 2)
+#define ZLOB_META_CTIME       (1u << 3)
+#define ZLOB_META_BTIME       (1u << 4) /* creation time (not on all filesystems) */
+#define ZLOB_META_INODE       (1u << 5)
+#define ZLOB_META_NLINK       (1u << 6)
+#define ZLOB_META_MODE        (1u << 7) /* permission bits (mode & 07777) */
+#define ZLOB_META_UID         (1u << 8)
+#define ZLOB_META_GID         (1u << 9)
+#define ZLOB_META_ALL         0x3FFu /* every attribute above (bits 0-9) */
 
 /* Walk behavior flags (zlob_walk_options_t.flags). All-zero options give a
  * plain walkdir-style traversal: hidden files included, .gitignore not
  * consulted, directories reported. */
-#define ZLOB_WALK_GITIGNORE       (1u << 0) /* honor (nested) .gitignore + .ignore; also skips .git */
-#define ZLOB_WALK_SKIP_HIDDEN     (1u << 1) /* skip dotfiles and don't descend into dot-dirs */
+#define ZLOB_WALK_GITIGNORE   (1u << 0) /* honor (nested) .gitignore + .ignore; also skips .git */
+#define ZLOB_WALK_SKIP_HIDDEN (1u << 1) /* skip dotfiles and don't descend into dot-dirs */
 #define ZLOB_WALK_FOLLOW_SYMLINKS (1u << 2)
 #define ZLOB_WALK_NO_REPORT_DIRS  (1u << 3) /* yield only non-directory entries */
 #define ZLOB_WALK_SORT            (1u << 4) /* sort zlob_walk_collect() results by path */

--- a/src/c_lib.zig
+++ b/src/c_lib.zig
@@ -180,31 +180,10 @@ fn finalizeSharedSliceResult(matches: []const []const u8, pzlob: *zlob_t) c_int 
 fn finalizeNoMatch(pattern: []const u8, nocheck: bool, pzlob: *zlob_t) c_int {
     if (!nocheck) return zlob_flags.ZLOB_NOMATCH;
 
-    const pathv_buf = allocator.alloc([*c]u8, 2) catch return zlob_flags.ZLOB_NOSPACE;
-    errdefer allocator.free(pathv_buf);
-    const pathlen_buf = allocator.alloc(usize, 1) catch {
-        allocator.free(pathv_buf);
-        return zlob_flags.ZLOB_NOSPACE;
-    };
-    errdefer allocator.free(pathlen_buf);
-
-    // NUL-terminated owned copy so C callers can treat it as a C string.
-    const owned = allocator.allocSentinel(u8, pattern.len, 0) catch {
-        allocator.free(pathv_buf);
-        allocator.free(pathlen_buf);
-        return zlob_flags.ZLOB_NOSPACE;
-    };
-    @memcpy(owned[0..pattern.len], pattern);
-
-    pathv_buf[0] = @ptrCast(owned.ptr);
-    pathv_buf[1] = null;
-    pathlen_buf[0] = pattern.len;
-
-    pzlob.zlo_pathc = 1;
-    pzlob.zlo_pathv = @ptrCast(pathv_buf.ptr);
+    // Emit in the shared format so zlobfree treats this like any other
+    // OWNS_STRINGS result.
+    zlob_impl.emitSingleResult(allocator, pzlob, pattern, false) catch return zlob_flags.ZLOB_NOSPACE;
     pzlob.zlo_offs = 0;
-    pzlob.zlo_pathlen = pathlen_buf.ptr;
-    pzlob.zlo_flags = zlob_flags.ZLOB_FLAGS_OWNS_STRINGS;
     return 0;
 }
 

--- a/src/c_lib.zig
+++ b/src/c_lib.zig
@@ -182,7 +182,9 @@ fn finalizeNoMatch(pattern: []const u8, nocheck: bool, pzlob: *zlob_t) c_int {
 
     // Emit in the shared format so zlobfree treats this like any other
     // OWNS_STRINGS result.
-    zlob_impl.emitSingleResult(allocator, pzlob, pattern, false) catch return zlob_flags.ZLOB_NOSPACE;
+    // Reserves no leading slots: the match-paths API does not support
+    // ZLOB_DOOFFS, and finalizeSharedSliceResult likewise zeroes zlo_offs.
+    zlob_impl.ResultsList.emitSingle(allocator, pzlob, 0, pattern, false) catch return zlob_flags.ZLOB_NOSPACE;
     pzlob.zlo_offs = 0;
     return 0;
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -139,52 +139,6 @@ pub fn buildPathInBuffer(buf: []u8, dir: []const u8, name: []const u8) []const u
     return buf[0..len];
 }
 
-pub const PathBuildResult = struct {
-    ptr: [*c]u8,
-    len: usize,
-    buf: []u8,
-};
-
-/// Optimized path builder that pre-allocates space for trailing slash if ZLOB_MARK is set.
-pub inline fn buildFullPathWithMark(
-    allocator: Allocator,
-    dirname: []const u8,
-    name: []const u8,
-    use_dirname: bool,
-    is_dir: bool,
-    flags: ZlobFlags,
-) !PathBuildResult {
-    const base_len = if (use_dirname)
-        dirname.len + 1 + name.len
-    else
-        name.len;
-
-    const needs_mark = flags.mark and is_dir;
-    const alloc_len = if (needs_mark) base_len + 1 else base_len;
-
-    const path_buf_slice = try allocator.allocSentinel(u8, alloc_len, 0);
-
-    if (use_dirname) {
-        @memcpy(path_buf_slice[0..dirname.len], dirname);
-        path_buf_slice[dirname.len] = '/';
-        @memcpy(path_buf_slice[dirname.len + 1 ..][0..name.len], name);
-    } else {
-        @memcpy(path_buf_slice[0..name.len], name);
-    }
-
-    const final_len = if (needs_mark) blk: {
-        path_buf_slice[base_len] = '/';
-        path_buf_slice[base_len + 1] = 0;
-        break :blk base_len + 1;
-    } else base_len;
-
-    return .{
-        .ptr = @ptrCast(path_buf_slice.ptr),
-        .len = final_len,
-        .buf = path_buf_slice,
-    };
-}
-
 /// Expand tilde (~) in patterns to home directory.
 /// Returns null if ZLOB_TILDE_CHECK is set and expansion fails.
 pub fn expandTilde(allocator: Allocator, pattern: [:0]const u8, flags: ZlobFlags) !?[:0]const u8 {

--- a/src/walker.zig
+++ b/src/walker.zig
@@ -81,12 +81,6 @@ pub const HiddenConfig = struct {
         .include_hidden = true,
     };
 
-    /// Include "." and ".." only (for patterns like ".*" that start with '.')
-    pub const dots_and_hidden: HiddenConfig = .{
-        .include_dot_entries = true,
-        .include_hidden = true,
-    };
-
     /// Include hidden files but not "." and ".." (for ZLOB_PERIOD without dot pattern)
     pub const hidden_only: HiddenConfig = .{
         .include_dot_entries = false,
@@ -235,6 +229,24 @@ fn statAtFollow(dir_fd: std.posix.fd_t, name_z: [*:0]const u8) ?ResolvedSym {
     return .{ .is_dir = isDirMode(st.mode), .key = keyFromCStat(st) };
 }
 
+/// Length of the NUL-terminated name in a dirent record, scanned a word at a
+/// time. Returns area_len if no NUL is present.
+/// SAFETY: reads in 8-byte words, so every caller must pass the kernel 8 fewer
+/// bytes than its buffer actually holds.
+inline fn direntNameLen(area_ptr: [*]const u8, area_len: usize) usize {
+    const lo: u64 = 0x0101010101010101;
+    const hi: u64 = 0x8080808080808080;
+    var k: usize = 0;
+    while (k < area_len) : (k += 8) {
+        const w = mem.readInt(u64, area_ptr[k..][0..8], .little);
+        const zero_mask = (w -% lo) & ~w & hi;
+        if (zero_mask != 0) {
+            return @min(k + (@ctz(zero_mask) >> 3), area_len);
+        }
+    }
+    return area_len;
+}
+
 inline fn shouldSkipEntry(name: []const u8, hidden: HiddenConfig) bool {
     if (name.len == 0) return true;
 
@@ -288,6 +300,11 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
     // reallocation. Grows as needed for pathological cases (huge flat dirs).
     dir_stack: std.ArrayList(DirEntry),
 
+    // Saved paths of the directories on dir_stack, since siblings overwrite
+    // path_buffer before we pop. dir_stack is strict LIFO, so the popped entry
+    // always owns this buffer's tail and releasing it is a shrink.
+    path_stack: std.ArrayList(u8),
+
     // Cycle-detection set for follow_symlinks. Populated lazily — only when
     // a symlink-to-dir is descended into. Empty (and free) when follow_symlinks
     // is disabled.
@@ -315,18 +332,18 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
     const DirEntry = struct {
         fd: posix.fd_t,
         depth: u16,
-        path_len: u16, // Path length when this dir was pushed
-        // Store the actual path content to restore when we pop this directory
-        // This is needed because sibling directories overwrite each other in path_buffer
-        path_content: [256]u8,
+        // Where this dir's path lives in path_stack.
+        path_len: u16,
+        path_off: u32,
     };
 
     pub fn init(allocator: Allocator, io: Io, start_path: []const u8, config: WalkerConfig) !RecursiveGetdents64Walker {
         _ = io; // Linux getdents64 backend uses raw syscalls; accepted for API parity with StdFsWalker.
 
         // Use smaller buffer for single-directory iteration (max_depth=0)
-        // since we won't be recursing and don't need as much buffering
-        const buffer_size = if (config.max_depth == 0) 8192 else config.getdents_buffer_size;
+        // since we won't be recursing and don't need as much buffering.
+        // Floored so the 8 bytes reserved for direntNameLen stay meaningful.
+        const buffer_size = @max(if (config.max_depth == 0) 8192 else config.getdents_buffer_size, 512);
         const buffer = try allocator.alignedAlloc(u8, .@"8", buffer_size);
         errdefer allocator.free(buffer);
 
@@ -361,6 +378,7 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
             .allocator = allocator,
             .config = config,
             .dir_stack = dir_stack,
+            .path_stack = std.ArrayList(u8).empty,
             .visited = visited,
             .current_fd = start_fd,
             .current_depth = 0,
@@ -404,6 +422,7 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
         }
 
         self.dir_stack.deinit(self.allocator);
+        self.path_stack.deinit(self.allocator);
         self.visited.deinit(self.allocator);
 
         if (self.getdents_buffer.len > 0) {
@@ -422,8 +441,9 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
                 }
             }
 
-            // buffer free - read more from current directory
-            const bytes_read = linux.getdents64(self.current_fd, self.getdents_buffer.ptr, self.getdents_buffer.len);
+            // buffer free - read more from current directory.
+            // Short by 8: see direntNameLen.
+            const bytes_read = linux.getdents64(self.current_fd, self.getdents_buffer.ptr, self.getdents_buffer.len - 8);
 
             if (@as(isize, @bitCast(bytes_read)) < 0 or bytes_read == 0) {
                 // Current directory exhausted or error - close it and pop next from stack
@@ -437,9 +457,12 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
                 self.current_fd = next_dir.fd;
                 self.current_depth = next_dir.depth;
                 self.path_len = next_dir.path_len;
-                // Restore the path content that was saved when this directory was pushed
-                const copy_len = @min(next_dir.path_len, 256);
-                @memcpy(self.path_buffer[0..copy_len], next_dir.path_content[0..copy_len]);
+                // Restore this dir's saved path, then release its bytes.
+                @memcpy(
+                    self.path_buffer[0..next_dir.path_len],
+                    self.path_stack.items[next_dir.path_off..][0..next_dir.path_len],
+                );
+                self.path_stack.shrinkRetainingCapacity(next_dir.path_off);
 
                 self.getdents_offset = 0;
                 self.getdents_len = 0;
@@ -453,20 +476,33 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
 
     fn parseNextEntry(self: *RecursiveGetdents64Walker) ?Entry {
         const base = self.getdents_offset;
-        if (base + 19 > self.getdents_len) return null;
+        // Too few bytes left for a dirent header. Consume the remainder: the
+        // caller loops until the offset reaches the length.
+        if (base + 19 > self.getdents_len) {
+            @branchHint(.unlikely);
+            self.getdents_offset = self.getdents_len;
+            return null;
+        }
 
         const reclen = mem.readInt(u16, self.getdents_buffer[base + 16 ..][0..2], .little);
         const d_type = self.getdents_buffer[base + 18];
 
-        const name_start = base + 19;
-        var name_len: usize = 0;
-        while (name_start + name_len < base + reclen and
-            self.getdents_buffer[name_start + name_len] != 0) : (name_len += 1)
-        {}
-
+        // Guard against malformed (FUSE) records: a zero reclen would spin
+        // forever, and a short one underflows the name area below.
+        if (reclen < 19 or base + reclen > self.getdents_len) {
+            @branchHint(.unlikely);
+            self.getdents_offset = self.getdents_len;
+            return null;
+        }
         self.getdents_offset += reclen;
 
-        const name = self.getdents_buffer[name_start..][0..name_len];
+        // Knowing the terminator was found lets us borrow the name as a C
+        // string for openat/fstatat below instead of copying it out.
+        const name_start = base + 19;
+        const name_area = self.getdents_buffer[name_start .. base + reclen];
+        const name_len = direntNameLen(name_area.ptr, name_area.len);
+        const name_terminated = name_len < name_area.len;
+        const name = name_area[0..name_len];
 
         // Unified filtering for ".", "..", and hidden files
         if (shouldSkipEntry(name, self.config.hidden)) return null;
@@ -504,10 +540,8 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
             else
                 true;
 
-            if (should_descend) {
-                var name_z: [256]u8 = undefined;
-                @memcpy(name_z[0..name.len], name);
-                name_z[name.len] = 0;
+            if (should_descend and name_terminated) {
+                const name_z = name_area[0..name.len :0];
 
                 // For symlink entries under follow mode: pre-flight
                 // fstatat(FOLLOW) to confirm dir + cycle BEFORE openat.
@@ -515,14 +549,16 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
                 // big win on symlink-heavy trees (node_modules, bazel-out).
                 const skip_descend: bool = blk: {
                     if (kind != .sym_link) break :blk false;
-                    const res = statAtFollow(self.current_fd, name_z[0..name.len :0]) orelse break :blk true;
+                    const res = statAtFollow(self.current_fd, name_z) orelse break :blk true;
                     if (!res.is_dir) break :blk true;
                     const gop = self.visited.getOrPut(self.allocator, res.key) catch break :blk true;
                     break :blk gop.found_existing;
                 };
 
                 if (!skip_descend) {
-                    if (posix.openat(self.current_fd, name_z[0..name.len :0], .{
+                    // openatZ, not openat: the slice overload would re-copy
+                    // and rescan the name via toPosixPath.
+                    if (posix.openatZ(self.current_fd, name_z.ptr, .{
                         .ACCMODE = .RDONLY,
                         .DIRECTORY = true,
                         .CLOEXEC = true,
@@ -543,17 +579,20 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
                         } else {
                             // Push to stack - processed after current dir is exhausted.
                             // Save path content; sibling dirs overwrite path_buffer.
-                            var entry: DirEntry = .{
-                                .fd = subdir_fd,
-                                .depth = self.current_depth + 1,
-                                .path_len = @intCast(self.path_len),
-                                .path_content = undefined,
-                            };
-                            const copy_len = @min(self.path_len, 256);
-                            @memcpy(entry.path_content[0..copy_len], self.path_buffer[0..copy_len]);
-                            self.dir_stack.append(self.allocator, entry) catch {
+                            const path_off = self.path_stack.items.len;
+                            if (self.path_stack.appendSlice(self.allocator, self.path_buffer[0..self.path_len])) {
+                                self.dir_stack.append(self.allocator, .{
+                                    .fd = subdir_fd,
+                                    .depth = self.current_depth + 1,
+                                    .path_len = @intCast(self.path_len),
+                                    .path_off = @intCast(path_off),
+                                }) catch {
+                                    self.path_stack.shrinkRetainingCapacity(path_off);
+                                    _ = linux.close(subdir_fd);
+                                };
+                            } else |_| {
                                 _ = linux.close(subdir_fd);
-                            };
+                            }
                         }
                     } else |_| {}
                 }
@@ -581,6 +620,9 @@ const StdFsWalker = struct {
 
     // Stack of directories to process (LIFO order)
     dir_stack: std.ArrayList(StackEntry),
+
+    // Saved paths of the directories on dir_stack, as in the getdents64 backend.
+    path_stack: std.ArrayList(u8),
 
     // (dev, ino) bookkeeping for follow_symlinks cycle detection.
     // Empty when follow_symlinks is disabled.
@@ -614,11 +656,9 @@ const StdFsWalker = struct {
     const StackEntry = struct {
         dir: std.Io.Dir,
         depth: usize,
-        path_len: usize,
-        // Heap-allocated path prefix to restore when popping
-        // This is needed because the path_buffer is shared and may be
-        // overwritten by sibling directory processing before we pop
-        path_prefix: []u8,
+        // Where this dir's path lives in path_stack.
+        path_len: u32,
+        path_off: u32,
     };
 
     pub fn init(allocator: Allocator, io: Io, start_path: []const u8, config: WalkerConfig) !StdFsWalker {
@@ -648,6 +688,7 @@ const StdFsWalker = struct {
             .io = io,
             .config = config,
             .dir_stack = dir_stack,
+            .path_stack = std.ArrayList(u8).empty,
             .visited = visited,
             .current_dir = dir,
             .reader = .{
@@ -694,14 +735,12 @@ const StdFsWalker = struct {
             dir.close(io);
         }
 
-        // Close any remaining stacked directories and free path prefixes
+        // Close any remaining stacked directories
         for (self.dir_stack.items) |*entry| {
             entry.dir.close(io);
-            if (entry.path_prefix.len > 0) {
-                self.allocator.free(entry.path_prefix);
-            }
         }
         self.dir_stack.deinit(self.allocator);
+        self.path_stack.deinit(self.allocator);
         self.visited.deinit(self.allocator);
     }
 
@@ -783,21 +822,20 @@ const StdFsWalker = struct {
                             if (cycle) {
                                 sub.close(io);
                             } else {
-                                const path_copy = self.allocator.alloc(u8, self.path_len) catch {
+                                const path_off = self.path_stack.items.len;
+                                if (self.path_stack.appendSlice(self.allocator, self.path_buffer[0..self.path_len])) {
+                                    self.dir_stack.append(self.allocator, .{
+                                        .dir = sub,
+                                        .depth = self.current_depth + 1,
+                                        .path_len = @intCast(self.path_len),
+                                        .path_off = @intCast(path_off),
+                                    }) catch {
+                                        self.path_stack.shrinkRetainingCapacity(path_off);
+                                        sub.close(io);
+                                    };
+                                } else |_| {
                                     sub.close(io);
-                                    continue;
-                                };
-                                @memcpy(path_copy, self.path_buffer[0..self.path_len]);
-
-                                self.dir_stack.append(self.allocator, .{
-                                    .dir = sub,
-                                    .depth = self.current_depth + 1,
-                                    .path_len = self.path_len,
-                                    .path_prefix = path_copy,
-                                }) catch {
-                                    self.allocator.free(path_copy);
-                                    sub.close(io);
-                                };
+                                }
                             }
                         } else |_| {}
                     }
@@ -857,11 +895,13 @@ const StdFsWalker = struct {
             self.batch_index = 0;
             self.batch_len = 0;
             self.current_depth = next_entry.depth;
-            // Restore the path prefix from when we pushed this directory
-            @memcpy(self.path_buffer[0..next_entry.path_len], next_entry.path_prefix);
+            // Restore this dir's saved path, then release its bytes.
+            @memcpy(
+                self.path_buffer[0..next_entry.path_len],
+                self.path_stack.items[next_entry.path_off..][0..next_entry.path_len],
+            );
             self.path_len = next_entry.path_len;
-            // Free the path prefix allocation
-            self.allocator.free(next_entry.path_prefix);
+            self.path_stack.shrinkRetainingCapacity(next_entry.path_off);
         }
     }
 };
@@ -891,9 +931,11 @@ pub const SingleDirIterator = struct {
     /// Open a directory for single-level iteration using raw syscalls.
     /// If base_dir is provided, opens path relative to it; otherwise relative to cwd.
     /// hidden_config controls filtering of ".", "..", and hidden files.
-    pub fn open(path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig) !SingleDirIterator {
+    /// Open just the directory fd, so callers embedding this iterator can
+    /// construct it in place rather than moving it out of an error union.
+    pub fn openDirFd(path: []const u8, base_dir: ?std.Io.Dir) !i32 {
         if (!is_linux) {
-            @compileError("SingleDirIterator.open requires Linux");
+            @compileError("SingleDirIterator.openDirFd requires Linux");
         }
 
         // Build null-terminated path on stack
@@ -905,20 +947,27 @@ pub const SingleDirIterator = struct {
         const flags = linux.O{ .ACCMODE = .RDONLY, .DIRECTORY = true, .CLOEXEC = true };
 
         // Use raw syscall for maximum performance
-        const fd: i32 = if (base_dir) |bd| blk: {
-            const rc = linux.openat(bd.handle, &path_z, flags, 0);
-            const signed: isize = @bitCast(rc);
-            if (signed < 0) return error.AccessDenied;
-            break :blk @intCast(rc);
-        } else blk: {
-            const rc = linux.openat(linux.AT.FDCWD, &path_z, flags, 0);
-            const signed: isize = @bitCast(rc);
-            if (signed < 0) return error.AccessDenied;
-            break :blk @intCast(rc);
+        const dir_fd = if (base_dir) |bd| bd.handle else linux.AT.FDCWD;
+        const rc = linux.openat(dir_fd, &path_z, flags, 0);
+        // Map onto the same error set std.Io.Dir.openDir produces so
+        // openHandled reports an accurate errno through ErrCallbackFn.
+        return switch (linux.errno(rc)) {
+            .SUCCESS => @intCast(rc),
+            .NOENT => error.FileNotFound,
+            .NOTDIR => error.NotDir,
+            .ACCES => error.AccessDenied,
+            .LOOP => error.SymLinkLoop,
+            .NAMETOOLONG => error.NameTooLong,
+            .NOMEM => error.SystemResources,
+            .BADF => error.InvalidHandle,
+            .INVAL => error.InvalidArgument,
+            else => error.AccessDenied,
         };
+    }
 
+    pub fn open(path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig) !SingleDirIterator {
         return SingleDirIterator{
-            .fd = fd,
+            .fd = try openDirFd(path, base_dir),
             .buffer = undefined,
             .offset = 0,
             .len = 0,
@@ -940,17 +989,21 @@ pub const SingleDirIterator = struct {
                 const base = self.offset;
                 if (base + 19 > self.len) break;
 
-                const reclen = @as(u16, self.buffer[base + 16]) | (@as(u16, self.buffer[base + 17]) << 8);
+                const reclen = mem.readInt(u16, self.buffer[base + 16 ..][0..2], .little);
                 const d_type = self.buffer[base + 18];
 
+                // Guard against malformed (FUSE) records: a zero reclen would
+                // spin forever, a short one underflows the name area below.
+                if (reclen < 19 or base + reclen > self.len) {
+                    @branchHint(.unlikely);
+                    self.offset = self.len;
+                    break;
+                }
                 self.offset += reclen;
 
-                // Get name directly - it starts at offset 19 and is null-terminated
-                const name_ptr = self.buffer[base + 19 ..].ptr;
-                var name_len: usize = 0;
-                while (name_ptr[name_len] != 0 and name_len < reclen - 19) : (name_len += 1) {}
-
-                const name = name_ptr[0..name_len];
+                // The name starts at offset 19, NUL-terminated in the record.
+                const name_area = self.buffer[base + 19 .. base + reclen];
+                const name = name_area[0..direntNameLen(name_area.ptr, name_area.len)];
 
                 // Unified filtering for ".", "..", and hidden files
                 if (shouldSkipEntry(name, self.hidden)) continue;
@@ -965,8 +1018,8 @@ pub const SingleDirIterator = struct {
                 return IterEntry{ .name = name, .kind = kind };
             }
 
-            // Buffer exhausted - read more
-            const rc = linux.getdents64(self.fd, &self.buffer, self.buffer.len);
+            // Buffer exhausted - read more. Short by 8: see direntNameLen.
+            const rc = linux.getdents64(self.fd, &self.buffer, self.buffer.len - 8);
             const bytes_read: isize = @bitCast(rc);
             if (bytes_read <= 0) {
                 return null;
@@ -974,48 +1027,6 @@ pub const SingleDirIterator = struct {
 
             self.len = @intCast(bytes_read);
             self.offset = 0;
-        }
-    }
-};
-
-pub const StdDirIterator = struct {
-    io: Io,
-    dir: std.Io.Dir,
-    iter: std.Io.Dir.Iterator,
-    hidden: HiddenConfig,
-
-    pub const IterEntry = struct {
-        name: []const u8,
-        kind: EntryKind,
-    };
-
-    pub fn open(io: Io, path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig) !StdDirIterator {
-        const root = base_dir orelse std.Io.Dir.cwd();
-        var dir = try root.openDir(io, path, .{ .iterate = true });
-        return StdDirIterator{
-            .io = io,
-            .dir = dir,
-            .iter = dir.iterate(),
-            .hidden = hidden_config,
-        };
-    }
-
-    pub fn close(self: *StdDirIterator) void {
-        self.dir.close(self.io);
-    }
-
-    pub fn next(self: *StdDirIterator) ?IterEntry {
-        while (true) {
-            const entry = self.iter.next(self.io) catch return null;
-            if (entry) |e| {
-                // Unified filtering for ".", "..", and hidden files
-                if (shouldSkipEntry(e.name, self.hidden)) continue;
-                return IterEntry{
-                    .name = e.name,
-                    .kind = e.kind,
-                };
-            }
-            return null;
         }
     }
 };
@@ -1046,9 +1057,17 @@ pub const DirIterator = struct {
         }
     };
 
+    const is_linux = builtin.os.tag == .linux;
+    // Empty payload off Linux, where this variant is never constructed.
+    const GetdentsIter = if (is_linux) SingleDirIterator else struct {};
+
     io: Io,
-    /// Internal state - either real fs, std_fs (for Windows), or ALTDIRFUNC mode
+    /// Internal state - getdents64 (Linux), C readdir (other POSIX),
+    /// std.Io (Windows/no-libc fallback), or ALTDIRFUNC callbacks.
     mode: union(enum) {
+        /// Raw getdents64 syscalls (Linux only). Avoids opendir's per-directory
+        /// buffer malloc and the per-entry readdir call.
+        getdents: GetdentsIter,
         /// Real filesystem using C's opendir/readdir (POSIX only)
         real_fs: struct {
             dir: ?*c.DIR,
@@ -1126,7 +1145,11 @@ pub const DirIterator = struct {
     /// If base_dir is provided, opens path relative to it; otherwise relative to cwd.
     /// hidden_config controls filtering of ".", "..", and hidden files.
     /// fs allows using ALTDIRFUNC callbacks for virtual filesystem support.
-    pub fn openWithProvider(io: Io, path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig, fs: AltFs) !DirIterator {
+    /// Open a directory for iteration, constructing the iterator in place.
+    /// `out` is only initialized on success. Constructing in place matters:
+    /// the getdents mode embeds an 8 KiB buffer, and returning it by value
+    /// through an error union makes the compiler copy that buffer per open.
+    pub fn openWithProviderInto(out: *DirIterator, io: Io, path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig, fs: AltFs) !void {
         if (path.len >= 4096) return error.NameTooLong;
 
         if (fs.isAltDirFunc()) {
@@ -1138,7 +1161,7 @@ pub const DirIterator = struct {
             const handle = fs.opendir.?(&path_z);
             if (handle == null) return error.FileNotFound;
 
-            return DirIterator{
+            out.* = .{
                 .io = io,
                 .mode = .{ .alt_dirfunc = .{
                     .handle = handle,
@@ -1147,6 +1170,26 @@ pub const DirIterator = struct {
                 } },
                 .hidden = hidden_config,
             };
+            return;
+        }
+
+        // Linux: raw getdents64, no libc required. Handles base_dir natively
+        // via openat. `.buffer = undefined` keeps the 8 KiB scratch area
+        // untouched here.
+        if (is_linux) {
+            const fd = try SingleDirIterator.openDirFd(path, base_dir);
+            out.* = .{
+                .io = io,
+                .mode = .{ .getdents = .{
+                    .fd = fd,
+                    .buffer = undefined,
+                    .offset = 0,
+                    .len = 0,
+                    .hidden = hidden_config,
+                } },
+                .hidden = hidden_config,
+            };
+            return;
         }
 
         // When base_dir is set (need relative opens) or on Windows or when libc
@@ -1154,7 +1197,7 @@ pub const DirIterator = struct {
         if (base_dir != null or builtin.os.tag == .windows or !has_libc) {
             const root = base_dir orelse std.Io.Dir.cwd();
             var dir = try root.openDir(io, path, .{ .iterate = true });
-            return DirIterator{
+            out.* = .{
                 .io = io,
                 .mode = .{ .std_fs = .{
                     .dir = dir,
@@ -1162,6 +1205,7 @@ pub const DirIterator = struct {
                 } },
                 .hidden = hidden_config,
             };
+            return;
         }
 
         // Real filesystem: use C's optimized opendir/readdir
@@ -1169,20 +1213,24 @@ pub const DirIterator = struct {
         @memcpy(path_z[0..path.len], path);
         path_z[path.len] = 0;
 
-        const dir = if (base_dir) |_|
-            c.opendir(&path_z)
-        else
-            c.opendir(&path_z);
-
+        const dir = c.opendir(&path_z);
         if (dir == null) {
             return error.AccessDenied;
         }
 
-        return DirIterator{
+        out.* = .{
             .io = io,
             .mode = .{ .real_fs = .{ .dir = dir } },
             .hidden = hidden_config,
         };
+    }
+
+    /// By-value variant of openWithProviderInto. Prefer the Into form in hot
+    /// paths: this one copies the iterator, getdents buffer included.
+    pub fn openWithProvider(io: Io, path: []const u8, base_dir: ?std.Io.Dir, hidden_config: HiddenConfig, fs: AltFs) !DirIterator {
+        var it: DirIterator = undefined;
+        try openWithProviderInto(&it, io, path, base_dir, hidden_config, fs);
+        return it;
     }
 
     /// Open a directory for single-level iteration (backward compatible).
@@ -1196,11 +1244,57 @@ pub const DirIterator = struct {
     pub const OpenErrorConfig = struct {
         err_callback: ?ErrCallbackFn = null,
         abort_on_error: bool = false,
+        /// Path to report to err_callback instead of the opened one, for
+        /// fd-relative opens that should still report a full path.
+        report_path: ?[]const u8 = null,
     };
+
+    /// This directory as an openat() base for its children, when the platform
+    /// exposes a real fd. Saves the kernel re-resolving the path prefix.
+    pub fn relativeBase(self: *const DirIterator) ?std.Io.Dir {
+        if (comptime is_linux) {
+            return switch (self.mode) {
+                .getdents => |*g| .{ .handle = g.fd },
+                else => null,
+            };
+        }
+        return null;
+    }
 
     /// Open a directory with error callback handling.
     /// On failure, invokes err_callback (if set) and returns null instead of an error.
     /// Returns error.Aborted only when the callback requests abort or abort_on_error is set.
+    /// Open a directory with error callback handling, constructing the
+    /// iterator in place (see openWithProviderInto). Returns true when `out`
+    /// was initialized, false when the directory should be skipped, and
+    /// error.Aborted when the callback or abort_on_error demands it.
+    pub fn openHandledInto(
+        out: *DirIterator,
+        io: Io,
+        path: []const u8,
+        base_dir: ?std.Io.Dir,
+        hidden_config: HiddenConfig,
+        fs: AltFs,
+        err_config: OpenErrorConfig,
+    ) error{Aborted}!bool {
+        openWithProviderInto(out, io, path, base_dir, hidden_config, fs) catch |err| {
+            if (err_config.err_callback) |cb| {
+                const report = err_config.report_path orelse path;
+                var path_z: [4096:0]u8 = undefined;
+                const len = @min(report.len, 4095);
+                @memcpy(path_z[0..len], report[0..len]);
+                path_z[len] = 0;
+                if (cb(&path_z, zigErrorToPosix(err)) != 0) {
+                    return error.Aborted;
+                }
+            }
+            if (err_config.abort_on_error) return error.Aborted;
+            return false;
+        };
+        return true;
+    }
+
+    /// By-value variant of openHandledInto, kept for API compatibility.
     pub fn openHandled(
         io: Io,
         path: []const u8,
@@ -1209,23 +1303,16 @@ pub const DirIterator = struct {
         fs: AltFs,
         err_config: OpenErrorConfig,
     ) error{Aborted}!?DirIterator {
-        return openWithProvider(io, path, base_dir, hidden_config, fs) catch |err| {
-            if (err_config.err_callback) |cb| {
-                var path_z: [4096:0]u8 = undefined;
-                const len = @min(path.len, 4095);
-                @memcpy(path_z[0..len], path[0..len]);
-                path_z[len] = 0;
-                if (cb(&path_z, zigErrorToPosix(err)) != 0) {
-                    return error.Aborted;
-                }
-            }
-            if (err_config.abort_on_error) return error.Aborted;
-            return null;
-        };
+        var it: DirIterator = undefined;
+        if (!try openHandledInto(&it, io, path, base_dir, hidden_config, fs, err_config)) return null;
+        return it;
     }
 
     pub fn close(self: *DirIterator) void {
         switch (self.mode) {
+            .getdents => |*g| {
+                if (comptime is_linux) g.close();
+            },
             .real_fs => |*fs_mode| {
                 if (has_libc) {
                     if (fs_mode.dir) |d| {
@@ -1246,6 +1333,17 @@ pub const DirIterator = struct {
 
     pub fn next(self: *DirIterator) ?IterEntry {
         switch (self.mode) {
+            .getdents => |*g| {
+                if (comptime is_linux) {
+                    // SingleDirIterator applies the same hidden-config
+                    // filtering, and its names stay valid until the next
+                    // next() call, matching readdir's contract.
+                    if (g.next()) |entry| {
+                        return IterEntry{ .name = entry.name, .kind = entry.kind };
+                    }
+                }
+                return null;
+            },
             .real_fs => |fs_mode| {
                 if (!has_libc) return null;
 
@@ -1471,8 +1569,4 @@ test "HiddenConfig presets match expected values" {
     // hidden_only
     try std.testing.expect(HiddenConfig.hidden_only.include_dot_entries == false);
     try std.testing.expect(HiddenConfig.hidden_only.include_hidden == true);
-
-    // dots_and_hidden (same as include_all)
-    try std.testing.expect(HiddenConfig.dots_and_hidden.include_dot_entries == true);
-    try std.testing.expect(HiddenConfig.dots_and_hidden.include_hidden == true);
 }

--- a/src/walker.zig
+++ b/src/walker.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const dirent64 = @import("dirent");
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
 const Io = std.Io;
@@ -14,6 +15,8 @@ const errno = struct {
     const LOOP: c_int = 40;
     const NAMETOOLONG: c_int = 36;
     const NOMEM: c_int = 12;
+    const MFILE: c_int = 24;
+    const NFILE: c_int = 23;
     const INVAL: c_int = 22;
     const IO: c_int = 5;
 };
@@ -229,23 +232,10 @@ fn statAtFollow(dir_fd: std.posix.fd_t, name_z: [*:0]const u8) ?ResolvedSym {
     return .{ .is_dir = isDirMode(st.mode), .key = keyFromCStat(st) };
 }
 
-/// Length of the NUL-terminated name in a dirent record, scanned a word at a
-/// time. Returns area_len if no NUL is present.
-/// SAFETY: reads in 8-byte words, so every caller must pass the kernel 8 fewer
-/// bytes than its buffer actually holds.
-inline fn direntNameLen(area_ptr: [*]const u8, area_len: usize) usize {
-    const lo: u64 = 0x0101010101010101;
-    const hi: u64 = 0x8080808080808080;
-    var k: usize = 0;
-    while (k < area_len) : (k += 8) {
-        const w = mem.readInt(u64, area_ptr[k..][0..8], .little);
-        const zero_mask = (w -% lo) & ~w & hi;
-        if (zero_mask != 0) {
-            return @min(k + (@ctz(zero_mask) >> 3), area_len);
-        }
-    }
-    return area_len;
-}
+/// Length of the NUL-terminated name in a dirent record. Shared with the
+/// parallel walker's scanner; see `walker/dirent.zig` for the SWAR scan and its
+/// 8-byte over-read contract.
+const direntNameLen = dirent64.nameLen;
 
 inline fn shouldSkipEntry(name: []const u8, hidden: HiddenConfig) bool {
     if (name.len == 0) return true;
@@ -478,18 +468,18 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
         const base = self.getdents_offset;
         // Too few bytes left for a dirent header. Consume the remainder: the
         // caller loops until the offset reaches the length.
-        if (base + 19 > self.getdents_len) {
+        if (base + dirent64.NAME_OFFSET > self.getdents_len) {
             @branchHint(.unlikely);
             self.getdents_offset = self.getdents_len;
             return null;
         }
 
-        const reclen = mem.readInt(u16, self.getdents_buffer[base + 16 ..][0..2], .little);
-        const d_type = self.getdents_buffer[base + 18];
+        const reclen = mem.readInt(u16, self.getdents_buffer[base + dirent64.RECLEN_OFFSET ..][0..2], .little);
+        const d_type = self.getdents_buffer[base + dirent64.TYPE_OFFSET];
 
         // Guard against malformed (FUSE) records: a zero reclen would spin
         // forever, and a short one underflows the name area below.
-        if (reclen < 19 or base + reclen > self.getdents_len) {
+        if (reclen < dirent64.NAME_OFFSET or base + reclen > self.getdents_len) {
             @branchHint(.unlikely);
             self.getdents_offset = self.getdents_len;
             return null;
@@ -497,11 +487,15 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
         self.getdents_offset += reclen;
 
         // Knowing the terminator was found lets us borrow the name as a C
-        // string for openat/fstatat below instead of copying it out.
-        const name_start = base + 19;
+        // string for openat/fstatat below instead of copying it out
+        const name_start = base + dirent64.NAME_OFFSET;
         const name_area = self.getdents_buffer[name_start .. base + reclen];
         const name_len = direntNameLen(name_area.ptr, name_area.len);
-        const name_terminated = name_len < name_area.len;
+        // unrealistic path if kernel is broken and path doesn't have NUL
+        if (name_len == name_area.len) {
+            @branchHint(.unlikely);
+            return null;
+        }
         const name = name_area[0..name_len];
 
         // Unified filtering for ".", "..", and hidden files
@@ -540,7 +534,7 @@ const RecursiveGetdents64Walker = if (builtin.os.tag != .linux) struct {} else s
             else
                 true;
 
-            if (should_descend and name_terminated) {
+            if (should_descend) {
                 const name_z = name_area[0..name.len :0];
 
                 // For symlink entries under follow mode: pre-flight
@@ -959,6 +953,8 @@ pub const SingleDirIterator = struct {
             .LOOP => error.SymLinkLoop,
             .NAMETOOLONG => error.NameTooLong,
             .NOMEM => error.SystemResources,
+            .MFILE => error.ProcessFdQuotaExceeded,
+            .NFILE => error.SystemFdQuotaExceeded,
             .BADF => error.InvalidHandle,
             .INVAL => error.InvalidArgument,
             else => error.AccessDenied,
@@ -987,22 +983,22 @@ pub const SingleDirIterator = struct {
             // Try to get next entry from buffer
             while (self.offset < self.len) {
                 const base = self.offset;
-                if (base + 19 > self.len) break;
+                if (base + dirent64.NAME_OFFSET > self.len) break;
 
-                const reclen = mem.readInt(u16, self.buffer[base + 16 ..][0..2], .little);
-                const d_type = self.buffer[base + 18];
+                const reclen = mem.readInt(u16, self.buffer[base + dirent64.RECLEN_OFFSET ..][0..2], .little);
+                const d_type = self.buffer[base + dirent64.TYPE_OFFSET];
 
                 // Guard against malformed (FUSE) records: a zero reclen would
                 // spin forever, a short one underflows the name area below.
-                if (reclen < 19 or base + reclen > self.len) {
+                if (reclen < dirent64.NAME_OFFSET or base + reclen > self.len) {
                     @branchHint(.unlikely);
                     self.offset = self.len;
                     break;
                 }
                 self.offset += reclen;
 
-                // The name starts at offset 19, NUL-terminated in the record.
-                const name_area = self.buffer[base + 19 .. base + reclen];
+                // The name follows the header, NUL-terminated in the record.
+                const name_area = self.buffer[base + dirent64.NAME_OFFSET .. base + reclen];
                 const name = name_area[0..direntNameLen(name_area.ptr, name_area.len)];
 
                 // Unified filtering for ".", "..", and hidden files
@@ -1414,6 +1410,8 @@ fn zigErrorToPosix(err: anyerror) c_int {
         error.SymLinkLoop => errno.LOOP,
         error.NameTooLong => errno.NAMETOOLONG,
         error.SystemResources => errno.NOMEM,
+        error.ProcessFdQuotaExceeded => errno.MFILE,
+        error.SystemFdQuotaExceeded => errno.NFILE,
         error.InvalidHandle, error.InvalidArgument => errno.INVAL,
         else => errno.IO,
     };
@@ -1458,30 +1456,50 @@ test "walker basic" {
     try std.testing.expect(count > 0);
 }
 
+// direntNameLen lives in walker/dirent.zig, which is a module root and so
+// cannot host its own tests. They run from here instead.
+//
+// The bodies sit behind a comptime branch, not `error.SkipZigTest`: dirent.zig
+// refuses to compile off Linux, and a skipped test body would still be
+// semantically analyzed. Only the taken branch of a comptime-known `if` is.
 test "direntNameLen finds the terminator across word boundaries" {
-    // Names are laid out as the kernel writes them: NUL-terminated, then
-    // padded to the record length.
-    var area: [64]u8 = undefined;
-    for ([_]usize{ 0, 1, 7, 8, 9, 15, 16, 31 }) |name_len| {
-        @memset(&area, 'a');
-        area[name_len] = 0;
-        @memset(area[name_len + 1 ..], 0);
-        try std.testing.expectEqual(name_len, direntNameLen(&area, area.len));
+    if (comptime builtin.os.tag == .linux) {
+        // Names are laid out as the kernel writes them: NUL-terminated, then
+        // padded to the record length.
+        var area: [64]u8 = undefined;
+        for ([_]usize{ 0, 1, 7, 8, 9, 15, 16, 31 }) |name_len| {
+            @memset(&area, 'a');
+            area[name_len] = 0;
+            @memset(area[name_len + 1 ..], 0);
+            try std.testing.expectEqual(name_len, direntNameLen(&area, area.len));
+        }
     }
 }
 
 test "direntNameLen clamps when the area has no terminator" {
-    // A malformed record without a NUL must report the area length rather
-    // than running past it.
-    var area: [24]u8 = @splat('a');
-    try std.testing.expectEqual(area.len, direntNameLen(&area, area.len));
+    if (comptime builtin.os.tag == .linux) {
+        // A malformed record without a NUL must report the area length rather
+        // than running past it.
+        var area: [24]u8 = @splat('a');
+        try std.testing.expectEqual(area.len, direntNameLen(&area, area.len));
 
-    // Unterminated area whose length is not a multiple of the word size:
-    // the final word read spans past area_len, so the result must clamp.
-    var padded: [32]u8 = @splat('a');
-    @memset(padded[21..], 0);
-    try std.testing.expectEqual(@as(usize, 21), direntNameLen(&padded, 21));
-    try std.testing.expectEqual(@as(usize, 13), direntNameLen(&padded, 13));
+        // Unterminated area whose length is not a multiple of the word size:
+        // the final word read spans past area_len, so the result must clamp.
+        var padded: [32]u8 = @splat('a');
+        @memset(padded[21..], 0);
+        try std.testing.expectEqual(@as(usize, 21), direntNameLen(&padded, 21));
+        try std.testing.expectEqual(@as(usize, 13), direntNameLen(&padded, 13));
+    }
+}
+
+test "direntNameLen does not mistake high bytes for a terminator" {
+    if (comptime builtin.os.tag == .linux) {
+        // Bytes >= 0x80 (UTF-8 continuations) already have the high bit set,
+        // which is what the `& ~word` step exists to reject.
+        var area: [32]u8 = @splat(0xC3);
+        @memset(area[9..], 0);
+        try std.testing.expectEqual(@as(usize, 9), direntNameLen(&area, area.len));
+    }
 }
 
 test "EntryKind is std.Io.File.Kind" {

--- a/src/walker.zig
+++ b/src/walker.zig
@@ -1444,8 +1444,9 @@ pub const AltFs = struct {
 
 test "walker basic" {
     const allocator = std.testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    var walker = try DefaultWalker.init(allocator, ".", .{ .hidden = HiddenConfig.posix_default });
+    var walker = try DefaultWalker.init(allocator, io, ".", .{ .hidden = HiddenConfig.posix_default });
     defer walker.deinit();
 
     var count: usize = 0;
@@ -1455,6 +1456,32 @@ test "walker basic" {
     }
 
     try std.testing.expect(count > 0);
+}
+
+test "direntNameLen finds the terminator across word boundaries" {
+    // Names are laid out as the kernel writes them: NUL-terminated, then
+    // padded to the record length.
+    var area: [64]u8 = undefined;
+    for ([_]usize{ 0, 1, 7, 8, 9, 15, 16, 31 }) |name_len| {
+        @memset(&area, 'a');
+        area[name_len] = 0;
+        @memset(area[name_len + 1 ..], 0);
+        try std.testing.expectEqual(name_len, direntNameLen(&area, area.len));
+    }
+}
+
+test "direntNameLen clamps when the area has no terminator" {
+    // A malformed record without a NUL must report the area length rather
+    // than running past it.
+    var area: [24]u8 = @splat('a');
+    try std.testing.expectEqual(area.len, direntNameLen(&area, area.len));
+
+    // Unterminated area whose length is not a multiple of the word size:
+    // the final word read spans past area_len, so the result must clamp.
+    var padded: [32]u8 = @splat('a');
+    @memset(padded[21..], 0);
+    try std.testing.expectEqual(@as(usize, 21), direntNameLen(&padded, 21));
+    try std.testing.expectEqual(@as(usize, 13), direntNameLen(&padded, 13));
 }
 
 test "EntryKind is std.Io.File.Kind" {

--- a/src/walker/dirent.zig
+++ b/src/walker/dirent.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const mem = std.mem;
+
+comptime {
+    if (builtin.os.tag != .linux) {
+        @compileError("dirent64 records are a Linux getdents64 concept; " ++
+            "this module must not be referenced on other targets");
+    }
+}
+
+pub const INO_OFFSET = 0;
+pub const RECLEN_OFFSET = 16;
+pub const TYPE_OFFSET = 18;
+pub const NAME_OFFSET = 19;
+
+comptime {
+    const d64 = std.os.linux.dirent64;
+    std.debug.assert(@offsetOf(d64, "ino") == INO_OFFSET);
+    std.debug.assert(@offsetOf(d64, "reclen") == RECLEN_OFFSET);
+    std.debug.assert(@offsetOf(d64, "type") == TYPE_OFFSET);
+    std.debug.assert(@offsetOf(d64, "name") == NAME_OFFSET);
+}
+
+/// Length of the NUL-terminated name in a dirent record, scanned a word at a
+/// time. Returns area_len if no NUL is present.
+/// (yes it's a better faster SWAR implmeented `strnlen`)
+pub inline fn nameLen(area_ptr: [*]const u8, area_len: usize) usize {
+    const lo: u64 = 0x0101010101010101;
+    const hi: u64 = 0x8080808080808080;
+    var k: usize = 0;
+    while (k < area_len) : (k += 8) {
+        const w = mem.readInt(u64, area_ptr[k..][0..8], .little);
+        const zero_mask = (w -% lo) & ~w & hi;
+        if (zero_mask != 0) {
+            return @min(k + (@ctz(zero_mask) >> 3), area_len);
+        }
+    }
+    return area_len;
+}

--- a/src/walker/scan.zig
+++ b/src/walker/scan.zig
@@ -118,7 +118,8 @@ fn scanLinux(sh: *SharedWorkerState, w: *Worker, fd: posix.fd_t) WalkError!void 
     const only_inode = sh.options.meta.toInt() == (MetaMask{ .inode = true }).toInt();
 
     while (true) {
-        const rc = linux.getdents64(fd, w.io_buf.ptr, w.io_buf.len);
+        // Short by 8 so the word-at-a-time name scan below stays in bounds.
+        const rc = linux.getdents64(fd, w.io_buf.ptr, w.io_buf.len - 8);
         const n: isize = @bitCast(rc);
         if (n < 0) {
             return switch (linux.errno(rc)) {
@@ -141,10 +142,20 @@ fn scanLinux(sh: *SharedWorkerState, w: *Worker, fd: posix.fd_t) WalkError!void 
             off += reclen;
 
             const name_ptr: [*:0]const u8 = @ptrCast(w.io_buf.ptr + base + 19);
-            // The name is NUL-terminated within the record, so a bounded
-            // vectorized scan beats compiler_rt's byte-wise strlen.
+            // The name is NUL-terminated within the record; scan a word at a
+            // time. Vectorized scans do not amortize at these lengths.
             const name_area = w.io_buf[base + 19 .. base + reclen];
-            const name_len = mem.indexOfScalar(u8, name_area, 0) orelse name_area.len;
+            const name_len = blk: {
+                const lo: u64 = 0x0101010101010101;
+                const hi: u64 = 0x8080808080808080;
+                var k: usize = 0;
+                while (k < name_area.len) : (k += 8) {
+                    const word = mem.readInt(u64, name_area.ptr[k..][0..8], .little);
+                    const zero_mask = (word -% lo) & ~word & hi;
+                    if (zero_mask != 0) break :blk @min(k + (@ctz(zero_mask) >> 3), name_area.len);
+                }
+                break :blk name_area.len;
+            };
             const name = name_area[0..name_len];
             if (name.len == 0) continue;
             if (name[0] == '.' and (name.len == 1 or (name.len == 2 and name[1] == '.'))) continue;

--- a/src/walker/scan.zig
+++ b/src/walker/scan.zig
@@ -15,19 +15,18 @@ const std = @import("std");
 const builtin = @import("builtin");
 const types = @import("types.zig");
 const worker = @import("worker.zig");
-const darwin = @import("scan_darwin.zig");
-const win = @import("scan_windows.zig");
 
-const mem = std.mem;
+const linux = @import("scan_linux.zig");
+const darwin = @import("scan_darwin.zig");
+const winows = @import("scan_windows.zig");
+
 const posix = std.posix;
-const linux = std.os.linux;
 const backend = types.backend;
 const is_posix_backend = types.is_posix_backend;
 const Handle = types.Handle;
 const EntryKind = types.EntryKind;
 const Metadata = types.Metadata;
 const MetaMask = types.MetaMask;
-const RawEntry = types.RawEntry;
 const SharedWorkerState = worker.SharedWorkerState;
 const Worker = worker.Worker;
 const closeFd = types.closeFd;
@@ -37,7 +36,7 @@ const NAME_BUF = types.NAME_BUF_Z_LENGTH;
 
 pub fn scanDir(sh: *SharedWorkerState, w: *Worker, handle: Handle) WalkError!void {
     if (backend == .linux_getdents) {
-        return scanLinux(sh, w, handle);
+        return linux.scanDir(sh, w, handle);
     } else if (backend == .darwin_bulk) {
         return scanDarwin(sh, w, handle);
     } else if (backend == .windows_ntdll) {
@@ -48,223 +47,12 @@ pub fn scanDir(sh: *SharedWorkerState, w: *Worker, handle: Handle) WalkError!voi
 }
 
 // ---------------------------------------------------------------------------
-// Scratch accumulation
-// ---------------------------------------------------------------------------
-
-inline fn noteIgnoreFile(w: *Worker, name: []const u8) void {
-    if (name.len == 10 and mem.eql(u8, name, ".gitignore")) {
-        w.saw_gitignore = true;
-    } else if (name.len == 7 and mem.eql(u8, name, ".ignore")) {
-        w.saw_ignore = true;
-    }
-}
-
-inline fn appendScratch(sh: *SharedWorkerState, w: *Worker, raw: RawEntry) WalkError!void {
-    const name = raw.name;
-    if (name.len == 0) {
-        @branchHint(.unlikely);
-        return;
-    }
-    if (name[0] == '.') {
-        @branchHint(.unlikely);
-        if (name.len == 1 or (name.len == 2 and name[1] == '.')) return;
-        noteIgnoreFile(w, name);
-    }
-    const off: u32 = @intCast(w.names.items.len);
-    try w.names.appendSlice(sh.allocator, name);
-    try w.entries.append(sh.allocator, .{
-        .name_off = off,
-        .name_len = @intCast(name.len),
-        .kind = raw.kind,
-    });
-    // Metadata rides in the parallel list only when the caller asked for it;
-    // processDir indexes it by entry position.
-    if (sh.options.meta.any()) {
-        try w.metas.append(sh.allocator, raw.meta);
-    }
-}
-
-inline fn appendScratchNoMeta(sh: *SharedWorkerState, w: *Worker, name: []const u8, kind: EntryKind) WalkError!void {
-    if (name.len == 0) {
-        @branchHint(.unlikely);
-        return;
-    }
-    if (name[0] == '.') {
-        @branchHint(.unlikely);
-        if (name.len == 1 or (name.len == 2 and name[1] == '.')) return;
-        noteIgnoreFile(w, name);
-    }
-    const off: u32 = @intCast(w.names.items.len);
-    try w.names.appendSlice(sh.allocator, name);
-    try w.entries.append(sh.allocator, .{
-        .name_off = off,
-        .name_len = @intCast(name.len),
-        .kind = kind,
-    });
-}
-
-// ---------------------------------------------------------------------------
-// Linux: getdents64
-// ---------------------------------------------------------------------------
-
-fn scanLinux(sh: *SharedWorkerState, w: *Worker, fd: posix.fd_t) WalkError!void {
-    if (builtin.os.tag != .linux) unreachable;
-    const DT_UNKNOWN: u8 = 0;
-    const DT_DIR: u8 = 4;
-    const DT_REG: u8 = 8;
-    const DT_LNK: u8 = 10;
-    const S_IFMT: u32 = 0o170000;
-    const want_stat = sh.options.meta.any();
-    const only_inode = sh.options.meta.toInt() == (MetaMask{ .inode = true }).toInt();
-
-    while (true) {
-        // Short by 8 so the word-at-a-time name scan below stays in bounds.
-        const rc = linux.getdents64(fd, w.io_buf.ptr, w.io_buf.len - 8);
-        const n: isize = @bitCast(rc);
-        if (n < 0) {
-            return switch (linux.errno(rc)) {
-                .ACCES => error.PermissionDenied,
-                else => error.ReadFailed,
-            };
-        }
-        if (n == 0) return;
-        const len: usize = @intCast(n);
-
-        var off: usize = 0;
-        while (off + 19 <= len) {
-            const base = off;
-            const d_ino = mem.readInt(u64, w.io_buf[base..][0..8], .little);
-            const reclen = mem.readInt(u16, w.io_buf[base + 16 ..][0..2], .little);
-            const d_type = w.io_buf[base + 18];
-            // A zero reclen would loop forever; only a malformed (FUSE) fs can
-            // produce one.
-            if (reclen == 0) return error.ReadFailed;
-            off += reclen;
-
-            const name_ptr: [*:0]const u8 = @ptrCast(w.io_buf.ptr + base + 19);
-            // The name is NUL-terminated within the record; scan a word at a
-            // time. Vectorized scans do not amortize at these lengths.
-            const name_area = w.io_buf[base + 19 .. base + reclen];
-            const name_len = blk: {
-                const lo: u64 = 0x0101010101010101;
-                const hi: u64 = 0x8080808080808080;
-                var k: usize = 0;
-                while (k < name_area.len) : (k += 8) {
-                    const word = mem.readInt(u64, name_area.ptr[k..][0..8], .little);
-                    const zero_mask = (word -% lo) & ~word & hi;
-                    if (zero_mask != 0) break :blk @min(k + (@ctz(zero_mask) >> 3), name_area.len);
-                }
-                break :blk name_area.len;
-            };
-            const name = name_area[0..name_len];
-            if (name.len == 0) continue;
-            if (name[0] == '.' and (name.len == 1 or (name.len == 2 and name[1] == '.'))) continue;
-
-            var kind: EntryKind = switch (d_type) {
-                DT_REG => .file,
-                DT_DIR => .directory,
-                DT_LNK => .sym_link,
-                else => .unknown,
-            };
-
-            var meta = Metadata{};
-            if (want_stat or d_type == DT_UNKNOWN) {
-                if (only_inode and d_type != DT_UNKNOWN) {
-                    meta.inode = d_ino;
-                    meta.valid.inode = true;
-                } else {
-                    var stx: linux.Statx = undefined;
-                    var mask = sh.statx_mask;
-                    if (d_type == DT_UNKNOWN) mask.TYPE = true;
-                    const src = linux.statx(fd, name_ptr, linux.AT.SYMLINK_NOFOLLOW, mask, &stx);
-                    if (linux.errno(src) == .SUCCESS) {
-                        fillMetaFromStatx(&meta, &stx, sh.options.meta);
-                        if (d_type == DT_UNKNOWN and stx.mask.TYPE) {
-                            kind = switch (@as(u32, stx.mode) & S_IFMT) {
-                                0o040000 => .directory,
-                                0o100000 => .file,
-                                0o120000 => .sym_link,
-                                else => .unknown,
-                            };
-                        }
-                    }
-                }
-            }
-
-            try appendScratch(sh, w, .{ .name = name, .kind = kind, .meta = meta });
-        }
-    }
-}
-
-pub fn linuxStatxMask(want: MetaMask) if (builtin.os.tag == .linux) linux.STATX else void {
-    if (builtin.os.tag != .linux) return {};
-    return .{
-        .SIZE = want.size,
-        .MTIME = want.mtime,
-        .ATIME = want.atime,
-        .CTIME = want.ctime,
-        .BTIME = want.btime,
-        .INO = want.inode,
-        .NLINK = want.nlink,
-        .MODE = want.mode,
-        .UID = want.uid,
-        .GID = want.gid,
-    };
-}
-
-fn fillMetaFromStatx(meta: *Metadata, stx: *const linux.Statx, want: MetaMask) void {
-    if (builtin.os.tag != .linux) unreachable;
-    if (want.size and stx.mask.SIZE) {
-        meta.size = stx.size;
-        meta.valid.size = true;
-    }
-    if (want.mtime and stx.mask.MTIME) {
-        meta.mtime_ns = stx.mtime.sec *% std.time.ns_per_s +% stx.mtime.nsec;
-        meta.valid.mtime = true;
-    }
-    if (want.atime and stx.mask.ATIME) {
-        meta.atime_ns = stx.atime.sec *% std.time.ns_per_s +% stx.atime.nsec;
-        meta.valid.atime = true;
-    }
-    if (want.ctime and stx.mask.CTIME) {
-        meta.ctime_ns = stx.ctime.sec *% std.time.ns_per_s +% stx.ctime.nsec;
-        meta.valid.ctime = true;
-    }
-    if (want.btime and stx.mask.BTIME) {
-        meta.btime_ns = stx.btime.sec *% std.time.ns_per_s +% stx.btime.nsec;
-        meta.valid.btime = true;
-    }
-    if (want.inode and stx.mask.INO) {
-        meta.inode = stx.ino;
-        meta.valid.inode = true;
-    }
-    if (want.nlink and stx.mask.NLINK) {
-        meta.nlink = stx.nlink;
-        meta.valid.nlink = true;
-    }
-    if (want.mode and stx.mask.MODE) {
-        meta.mode = @as(u32, stx.mode) & 0o7777;
-        meta.valid.mode = true;
-    }
-    if (want.uid and stx.mask.UID) {
-        meta.uid = stx.uid;
-        meta.valid.uid = true;
-    }
-    if (want.gid and stx.mask.GID) {
-        meta.gid = stx.gid;
-        meta.valid.gid = true;
-    }
-}
-
-// ---------------------------------------------------------------------------
 // macOS: getattrlistbulk (with metadata) / getdirentries64 (without)
 // ---------------------------------------------------------------------------
 
 fn scanDarwin(sh: *SharedWorkerState, w: *Worker, fd: posix.fd_t) WalkError!void {
     if (comptime !darwin.supported) unreachable;
-    // No-metadata walks only need names + kind. getattrlistbulk would make the
-    // kernel assemble attribute records we never read (~25% slower per dir than
-    // getdirentries64 on APFS), so route around it.
+    // if we don't need meta use getdirentries64 backend
     if (!sh.options.meta.any()) {
         return scanDarwinNoMeta(sh, w, fd);
     }
@@ -276,7 +64,7 @@ fn scanDarwin(sh: *SharedWorkerState, w: *Worker, fd: posix.fd_t) WalkError!void
             error.ReadFailed => return error.ReadFailed,
         };
         const entry = raw orelse return;
-        try appendScratch(sh, w, entry);
+        try worker.appendScratch(sh, w, entry);
     }
 }
 
@@ -290,7 +78,7 @@ fn scanDarwinNoMeta(sh: *SharedWorkerState, w: *Worker, fd: posix.fd_t) WalkErro
         if (kind == .unknown) {
             kind = statKind(fd, entry.name) orelse .unknown;
         }
-        try appendScratchNoMeta(sh, w, entry.name, kind);
+        try worker.appendScratchNoMeta(sh, w, entry.name, kind);
     }
 }
 
@@ -334,7 +122,7 @@ fn scanPosixFallback(sh: *SharedWorkerState, w: *Worker, fd: posix.fd_t) WalkErr
                 }
             }
         }
-        try appendScratch(sh, w, .{ .name = name, .kind = kind, .meta = meta });
+        try worker.appendScratch(sh, w, .{ .name = name, .kind = kind, .meta = meta });
     }
 }
 
@@ -410,15 +198,15 @@ fn fillMetaFromCStat(meta: *Metadata, st: *const std.c.Stat, want: MetaMask) voi
 // ---------------------------------------------------------------------------
 
 fn scanWindows(sh: *SharedWorkerState, w: *Worker, handle: std.os.windows.HANDLE) WalkError!void {
-    if (comptime !win.supported) unreachable;
-    var scanner = win.Scanner.init(handle, w.io_buf, sh.options.meta);
+    if (comptime !winows.supported) unreachable;
+    var scanner = winows.Scanner.init(handle, w.io_buf, sh.options.meta);
     while (true) {
         const raw = scanner.next() catch |err| switch (err) {
             error.PermissionDenied => return error.PermissionDenied,
             error.ReadFailed => return error.ReadFailed,
         };
         const entry = raw orelse return;
-        try appendScratch(sh, w, entry);
+        try worker.appendScratch(sh, w, entry);
     }
 }
 
@@ -453,7 +241,7 @@ fn scanStdFs(sh: *SharedWorkerState, w: *Worker, handle: Handle) WalkError!void 
                     fillMetaFromIoStat(&meta, &st, sh.options.meta);
                 } else |_| {}
             }
-            try appendScratch(sh, w, .{ .name = name, .kind = entry.kind, .meta = meta });
+            try worker.appendScratch(sh, w, .{ .name = name, .kind = entry.kind, .meta = meta });
         }
     }
 }

--- a/src/walker/scan_linux.zig
+++ b/src/walker/scan_linux.zig
@@ -1,0 +1,174 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const types = @import("types.zig");
+const worker = @import("worker.zig");
+const dirent = @import("dirent");
+
+const mem = std.mem;
+const posix = std.posix;
+const linux = std.os.linux;
+const EntryKind = types.EntryKind;
+const Metadata = types.Metadata;
+const MetaMask = types.MetaMask;
+const SharedWorkerState = worker.SharedWorkerState;
+const Worker = worker.Worker;
+const WalkError = types.WalkError;
+
+pub const supported = builtin.os.tag == .linux;
+pub const StatxMask = if (supported) linux.STATX else void;
+
+const DT_UNKNOWN: u8 = 0;
+const DT_DIR: u8 = 4;
+const DT_REG: u8 = 8;
+const DT_LNK: u8 = 10;
+const S_IFMT: u32 = 0o170000;
+const S_IFDIR: u32 = 0o040000;
+const S_IFREG: u32 = 0o100000;
+const S_IFLNK: u32 = 0o120000;
+
+pub fn scanDir(sh: *SharedWorkerState, w: *Worker, fd: posix.fd_t) WalkError!void {
+    if (comptime !supported) unreachable;
+    const want_stat = sh.options.meta.any();
+    const only_inode = sh.options.meta.toInt() == (MetaMask{ .inode = true }).toInt();
+
+    while (true) {
+        // Short by 8 so the word-at-a-time name scan below stays in bounds.
+        const rc = linux.getdents64(fd, w.io_buf.ptr, w.io_buf.len - 8);
+        const n: isize = @bitCast(rc);
+        if (n < 0) {
+            return switch (linux.errno(rc)) {
+                .ACCES => error.PermissionDenied,
+                else => error.ReadFailed,
+            };
+        }
+        if (n == 0) return;
+        const len: usize = @intCast(n);
+
+        var off: usize = 0;
+        while (off + dirent.NAME_OFFSET <= len) {
+            const base = off;
+            const d_ino = mem.readInt(u64, w.io_buf[base + dirent.INO_OFFSET ..][0..8], .little);
+            const reclen = mem.readInt(u16, w.io_buf[base + dirent.RECLEN_OFFSET ..][0..2], .little);
+            const d_type = w.io_buf[base + dirent.TYPE_OFFSET];
+            // Guard against malformed (FUSE) records: a zero reclen would loop
+            // forever, a short one inverts the name area below, and an
+            // oversized one reads past what the kernel wrote.
+            if (reclen < dirent.NAME_OFFSET or base + reclen > len) {
+                @branchHint(.unlikely);
+                return error.ReadFailed;
+            }
+            off += reclen;
+
+            const name_ptr: [*:0]const u8 = @ptrCast(w.io_buf.ptr + base + dirent.NAME_OFFSET);
+            // The name is NUL-terminated within the record; scan a word at a
+            // time. Vectorized scans do not amortize at these lengths.
+            const name_area = w.io_buf[base + dirent.NAME_OFFSET .. base + reclen];
+
+            const name_len = dirent.nameLen(name_area.ptr, name_area.len);
+            // name byte that doesn't contain NUL byte technically impossible but who knows what to expect from kernel
+            if (name_area.len != 0 and name_len == name_area.len) {
+                @branchHint(.unlikely);
+                return error.ReadFailed;
+            }
+
+            const name = name_area[0..name_len];
+            if (name.len == 0) continue;
+            if (name[0] == '.' and (name.len == 1 or (name.len == 2 and name[1] == '.'))) continue;
+
+            var kind: EntryKind = switch (d_type) {
+                DT_REG => .file,
+                DT_DIR => .directory,
+                DT_LNK => .sym_link,
+                else => .unknown,
+            };
+
+            var meta = Metadata{};
+            if (want_stat or d_type == DT_UNKNOWN) {
+                if (only_inode and d_type != DT_UNKNOWN) {
+                    meta.inode = d_ino;
+                    meta.valid.inode = true;
+                } else {
+                    var stx: linux.Statx = undefined;
+                    var mask = sh.statx_mask;
+                    if (d_type == DT_UNKNOWN) mask.TYPE = true;
+                    const src = linux.statx(fd, name_ptr, linux.AT.SYMLINK_NOFOLLOW, mask, &stx);
+                    if (linux.errno(src) == .SUCCESS) {
+                        fillMeta(&meta, &stx, sh.options.meta);
+                        if (d_type == DT_UNKNOWN and stx.mask.TYPE) {
+                            kind = switch (@as(u32, stx.mode) & S_IFMT) {
+                                S_IFDIR => .directory,
+                                S_IFREG => .file,
+                                S_IFLNK => .sym_link,
+                                else => .unknown,
+                            };
+                        }
+                    }
+                }
+            }
+
+            try worker.appendScratch(sh, w, .{ .name = name, .kind = kind, .meta = meta });
+        }
+    }
+}
+
+/// Translate the caller's requested fields into a statx mask, so each entry's
+/// statx only asks the kernel for what will actually be read.
+pub fn statxMask(want: MetaMask) StatxMask {
+    if (comptime !supported) return {};
+    return .{
+        .SIZE = want.size,
+        .MTIME = want.mtime,
+        .ATIME = want.atime,
+        .CTIME = want.ctime,
+        .BTIME = want.btime,
+        .INO = want.inode,
+        .NLINK = want.nlink,
+        .MODE = want.mode,
+        .UID = want.uid,
+        .GID = want.gid,
+    };
+}
+
+fn fillMeta(meta: *Metadata, stx: *const linux.Statx, want: MetaMask) void {
+    if (comptime !supported) unreachable;
+    if (want.size and stx.mask.SIZE) {
+        meta.size = stx.size;
+        meta.valid.size = true;
+    }
+    if (want.mtime and stx.mask.MTIME) {
+        meta.mtime_ns = stx.mtime.sec *% std.time.ns_per_s +% stx.mtime.nsec;
+        meta.valid.mtime = true;
+    }
+    if (want.atime and stx.mask.ATIME) {
+        meta.atime_ns = stx.atime.sec *% std.time.ns_per_s +% stx.atime.nsec;
+        meta.valid.atime = true;
+    }
+    if (want.ctime and stx.mask.CTIME) {
+        meta.ctime_ns = stx.ctime.sec *% std.time.ns_per_s +% stx.ctime.nsec;
+        meta.valid.ctime = true;
+    }
+    if (want.btime and stx.mask.BTIME) {
+        meta.btime_ns = stx.btime.sec *% std.time.ns_per_s +% stx.btime.nsec;
+        meta.valid.btime = true;
+    }
+    if (want.inode and stx.mask.INO) {
+        meta.inode = stx.ino;
+        meta.valid.inode = true;
+    }
+    if (want.nlink and stx.mask.NLINK) {
+        meta.nlink = stx.nlink;
+        meta.valid.nlink = true;
+    }
+    if (want.mode and stx.mask.MODE) {
+        meta.mode = @as(u32, stx.mode) & 0o7777;
+        meta.valid.mode = true;
+    }
+    if (want.uid and stx.mask.UID) {
+        meta.uid = stx.uid;
+        meta.valid.uid = true;
+    }
+    if (want.gid and stx.mask.GID) {
+        meta.gid = stx.gid;
+        meta.valid.gid = true;
+    }
+}

--- a/src/walker/walker.zig
+++ b/src/walker/walker.zig
@@ -5,6 +5,7 @@ const mem = std.mem;
 const Allocator = std.mem.Allocator;
 const worker = @import("worker.zig");
 const scan = @import("scan.zig");
+const scan_linux = @import("scan_linux.zig");
 const compiled_pattern = @import("../compiled_pattern.zig");
 const ignore_rules_mod = @import("ignore_rules.zig");
 
@@ -197,13 +198,7 @@ fn walkImpl(
             return error.OutOfMemory;
     }
     defer if (compiled) |*c| c.deinit();
-
-    // Extra-ignore root: caller-supplied patterns turned into a synthetic
-    // .gitignore. `chainIgnored` checks it FIRST (deepest), so `!negation`
-    // rules override the project's discovered .gitignore — same precedence a
-    // deeper nested .gitignore would have. The walker holds one ref; the
-    // IgnoreRules surface holds another so post-walk `isIgnored` matches the
-    // same source set the walk used.
+    // custom ignore rules are treated as an extra ignore node in the very root of the tree
     const extra_root = try buildExtraIgnoreRoot(allocator, options.extra_ignore);
     defer if (extra_root) |root_node| root_node.release(allocator);
     if (extra_root) |x| ignore_rules.setExtra(x);
@@ -223,7 +218,7 @@ fn walkImpl(
         else
             &.{},
         .extra_ignore_root = extra_root,
-        .statx_mask = scan.linuxStatxMask(options.meta),
+        .statx_mask = scan_linux.statxMask(options.meta),
         .ignore_rules = ignore_rules,
     };
 

--- a/src/walker/worker.zig
+++ b/src/walker/worker.zig
@@ -238,6 +238,62 @@ fn workerThreadMain(ctx: *anyopaque) void {
     workerLoop(w.sh, w);
 }
 
+// ---------------------------------------------------------------------------
+// Scratch accumulation
+// ---------------------------------------------------------------------------
+
+inline fn noteIgnoreFile(w: *Worker, name: []const u8) void {
+    if (name.len == 10 and mem.eql(u8, name, ".gitignore")) {
+        w.saw_gitignore = true;
+    } else if (name.len == 7 and mem.eql(u8, name, ".ignore")) {
+        w.saw_ignore = true;
+    }
+}
+
+pub inline fn appendScratch(sh: *SharedWorkerState, w: *Worker, raw: types.RawEntry) WalkError!void {
+    const name = raw.name;
+    if (name.len == 0) {
+        @branchHint(.unlikely);
+        return;
+    }
+    if (name[0] == '.') {
+        @branchHint(.unlikely);
+        if (name.len == 1 or (name.len == 2 and name[1] == '.')) return;
+        noteIgnoreFile(w, name);
+    }
+    const off: u32 = @intCast(w.names.items.len);
+    try w.names.appendSlice(sh.allocator, name);
+    try w.entries.append(sh.allocator, .{
+        .name_off = off,
+        .name_len = @intCast(name.len),
+        .kind = raw.kind,
+    });
+    // Metadata rides in the parallel list only when the caller asked for it;
+    // processDir indexes it by entry position.
+    if (sh.options.meta.any()) {
+        try w.metas.append(sh.allocator, raw.meta);
+    }
+}
+
+pub inline fn appendScratchNoMeta(sh: *SharedWorkerState, w: *Worker, name: []const u8, kind: EntryKind) WalkError!void {
+    if (name.len == 0) {
+        @branchHint(.unlikely);
+        return;
+    }
+    if (name[0] == '.') {
+        @branchHint(.unlikely);
+        if (name.len == 1 or (name.len == 2 and name[1] == '.')) return;
+        noteIgnoreFile(w, name);
+    }
+    const off: u32 = @intCast(w.names.items.len);
+    try w.names.appendSlice(sh.allocator, name);
+    try w.entries.append(sh.allocator, .{
+        .name_off = off,
+        .name_len = @intCast(name.len),
+        .kind = kind,
+    });
+}
+
 pub fn workerLoop(state: *SharedWorkerState, worker: *Worker) void {
     // Lazy spawning is driven only by worker 0 (the calling thread): once it
     // has uncovered more than a couple of pending directories there is enough

--- a/src/zlob.zig
+++ b/src/zlob.zig
@@ -176,28 +176,7 @@ fn globLiteralPath(allocator: Allocator, path: []const u8, flags: ZlobFlags, pzl
     }
 
     const needs_slash = flags.mark and is_dir;
-    const final_len = return_path.len + (if (needs_slash) @as(usize, 1) else 0);
-
-    var path_copy = try allocator.allocSentinel(u8, final_len, 0);
-    @memcpy(path_copy[0..return_path.len], return_path);
-    if (needs_slash) {
-        path_copy[return_path.len] = '/';
-    }
-
-    const path_ptr: [*c]u8 = @ptrCast(path_copy.ptr);
-
-    const pathv_buf = try allocator.alloc([*c]u8, 2);
-    const result: [*c][*c]u8 = @ptrCast(pathv_buf.ptr);
-    result[0] = path_ptr;
-    result[1] = null;
-
-    const pathlen_buf = try allocator.alloc(usize, 1);
-    pathlen_buf[0] = final_len; // Length from slice - no strlen()!
-
-    pzlob.zlo_pathc = 1;
-    pzlob.zlo_pathv = result;
-    pzlob.zlo_pathlen = pathlen_buf.ptr;
-    pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
+    try emitSingleResult(allocator, pzlob, return_path, needs_slash);
 
     return true;
 }
@@ -227,33 +206,39 @@ pub const DT_DIR = std.c.DT.DIR;
 pub const ResultsList = struct {
     const INLINE_CAP = 32;
 
-    /// Heap-allocated buffers (null when using inline)
-    heap_paths: ?[*][*c]u8 = null,
+    /// Heap-allocated record buffers (null when using inline)
+    heap_offsets: ?[*]usize = null,
     heap_lengths: ?[*]usize = null,
 
     count: usize = 0,
     capacity: usize = INLINE_CAP,
     allocator: Allocator,
-    // Inline buffers for small result sets - avoids heap allocation for <=32 results
-    inline_paths: [INLINE_CAP][*c]u8 = undefined,
+    /// Backing storage for every path's bytes, each NUL-terminated. Records
+    /// reference it by offset so it can realloc freely as results accumulate;
+    /// offsets only become pointers in emit().
+    bytes: std.ArrayList(u8) = .empty,
+    // Inline record buffers for small result sets - avoids heap allocation
+    // for the records of <=32 results
+    inline_offsets: [INLINE_CAP]usize = undefined,
     inline_lengths: [INLINE_CAP]usize = undefined,
 
-    /// Initialize with inline (stack) capacity - zero heap allocations.
+    /// Initialize with inline (stack) record capacity.
     pub fn init(allocator: Allocator) ResultsList {
         return .{ .allocator = allocator };
     }
 
-    /// Initialize with pre-allocated capacity.
+    /// Initialize with pre-allocated record capacity.
     /// If requested capacity <= INLINE_CAP, uses the inline buffer (no heap alloc).
     /// Otherwise allocates on the heap.
     pub fn initWithCapacity(allocator: Allocator, capacity: usize) Allocator.Error!ResultsList {
         if (capacity <= INLINE_CAP) {
             return init(allocator);
         }
-        const hp = try allocator.alloc([*c]u8, capacity);
+        const ho = try allocator.alloc(usize, capacity);
+        errdefer allocator.free(ho);
         const hl = try allocator.alloc(usize, capacity);
         return .{
-            .heap_paths = hp.ptr,
+            .heap_offsets = ho.ptr,
             .heap_lengths = hl.ptr,
             .capacity = capacity,
             .allocator = allocator,
@@ -261,12 +246,12 @@ pub const ResultsList = struct {
     }
 
     inline fn isInline(self: *const ResultsList) bool {
-        return self.heap_paths == null;
+        return self.heap_offsets == null;
     }
 
-    /// Get pointer to current paths storage
-    inline fn pathsPtr(self: *ResultsList) [*][*c]u8 {
-        return self.heap_paths orelse @as([*][*c]u8, @ptrCast(&self.inline_paths));
+    /// Get pointer to current offsets storage
+    inline fn offsetsPtr(self: *ResultsList) [*]usize {
+        return self.heap_offsets orelse @as([*]usize, @ptrCast(&self.inline_offsets));
     }
 
     /// Get pointer to current lengths storage
@@ -276,102 +261,120 @@ pub const ResultsList = struct {
 
     pub fn deinit(self: *ResultsList) void {
         if (!self.isInline()) {
-            self.allocator.free(self.heap_paths.?[0..self.capacity]);
+            self.allocator.free(self.heap_offsets.?[0..self.capacity]);
             self.allocator.free(self.heap_lengths.?[0..self.capacity]);
         }
+        self.bytes.deinit(self.allocator);
     }
 
-    pub fn ensureTotalCapacity(self: *ResultsList, capacity: usize) Allocator.Error!void {
-        if (capacity <= self.capacity) return;
-        try self.grow(capacity);
-    }
-
-    /// Grow to at least the given capacity, spilling from inline to heap if needed.
+    /// Grow the record arrays to at least the given capacity, spilling from
+    /// inline to heap if needed.
     fn grow(self: *ResultsList, min_capacity: usize) Allocator.Error!void {
         const new_cap = @max(min_capacity, self.capacity * 2);
-        const new_paths = try self.allocator.alloc([*c]u8, new_cap);
+        const new_offsets = try self.allocator.alloc(usize, new_cap);
+        errdefer self.allocator.free(new_offsets);
         const new_lengths = try self.allocator.alloc(usize, new_cap);
         // Copy existing data
         if (self.count > 0) {
-            const src_p = self.pathsPtr();
-            const src_l = self.lengthsPtr();
-            @memcpy(new_paths[0..self.count], src_p[0..self.count]);
-            @memcpy(new_lengths[0..self.count], src_l[0..self.count]);
+            @memcpy(new_offsets[0..self.count], self.offsetsPtr()[0..self.count]);
+            @memcpy(new_lengths[0..self.count], self.lengthsPtr()[0..self.count]);
         }
         // Free old heap buffers (inline buffers are part of the struct, nothing to free)
         if (!self.isInline()) {
-            self.allocator.free(self.heap_paths.?[0..self.capacity]);
+            self.allocator.free(self.heap_offsets.?[0..self.capacity]);
             self.allocator.free(self.heap_lengths.?[0..self.capacity]);
         }
-        self.heap_paths = new_paths.ptr;
+        self.heap_offsets = new_offsets.ptr;
         self.heap_lengths = new_lengths.ptr;
         self.capacity = new_cap;
     }
 
-    /// Add a path with its known length - O(1) amortized
-    pub fn append(self: *ResultsList, ptr: [*c]u8, path_len: usize) Allocator.Error!void {
+    /// Reserve a record plus `path_len + 1` bytes and return the writable path
+    /// slice for the caller to fill. The trailing NUL is already placed.
+    pub fn addPath(self: *ResultsList, path_len: usize) Allocator.Error![]u8 {
         if (self.count >= self.capacity) {
             try self.grow(self.capacity + 1);
         }
-        const p = self.pathsPtr();
-        const l = self.lengthsPtr();
-        p[self.count] = ptr;
-        l[self.count] = path_len;
+        const off = self.bytes.items.len;
+        try self.bytes.ensureUnusedCapacity(self.allocator, path_len + 1);
+        self.bytes.items.len += path_len + 1;
+        self.bytes.items[off + path_len] = 0;
+        self.offsetsPtr()[self.count] = off;
+        self.lengthsPtr()[self.count] = path_len;
         self.count += 1;
+        return self.bytes.items[off..][0..path_len];
+    }
+
+    /// Copy a complete path into the shared buffer - O(1) amortized.
+    pub fn appendPath(self: *ResultsList, path: []const u8) Allocator.Error!void {
+        const dst = try self.addPath(path.len);
+        @memcpy(dst, path);
+    }
+
+    /// Drop the most recently added path, for filters that reject it after
+    /// it has already been built into the buffer.
+    pub fn discardLast(self: *ResultsList) void {
+        self.count -= 1;
+        self.bytes.items.len = self.offsetsPtr()[self.count];
     }
 
     pub fn len(self: *const ResultsList) usize {
         return self.count;
     }
 
-    /// Get the current paths as a slice
-    pub inline fn pathSlice(self: *ResultsList) [][*c]u8 {
-        return self.pathsPtr()[0..self.count];
+    /// View of the i-th path's bytes. Invalidated by any subsequent addPath.
+    pub fn getPath(self: *ResultsList, i: usize) []const u8 {
+        return self.bytes.items[self.offsetsPtr()[i]..][0..self.lengthsPtr()[i]];
     }
 
-    /// Get the current lengths as a slice
-    pub inline fn lengthSlice(self: *ResultsList) []usize {
-        return self.lengthsPtr()[0..self.count];
-    }
-
-    /// Transfer ownership of the paths array, adding a null terminator.
-    /// Returns a heap-allocated buffer with null terminator appended.
-    /// Note: count is NOT reset here so toOwnedLengths can still read it.
-    pub fn toOwnedPathv(self: *ResultsList) Allocator.Error![][*c]u8 {
+    /// Emit the collected results into `pzlob`:
+    ///   pathv:   [offs nulls][count pointers][null]         (offs+count+1 slots)
+    ///   pathlen: [count lengths][bytes base][bytes capacity] (count+2 slots)
+    /// Ownership of the byte buffer moves into the zlob_t, and the two slots
+    /// past the visible lengths let globfreeInternal release the whole result
+    /// set in three frees. They are invisible to C callers, which only ever
+    /// see zlo_pathlen as a pointer.
+    /// On error the list is unchanged and still safe to deinit.
+    pub fn emit(self: *ResultsList, offs: usize, pzlob: *zlob_t) Allocator.Error!void {
         const count = self.count;
-        // Always allocate exact-sized buffer and copy (simple + correct)
-        const buf = try self.allocator.alloc([*c]u8, count + 1);
-        if (count > 0) {
-            const src = self.pathsPtr();
-            @memcpy(buf[0..count], src[0..count]);
-        }
-        buf[count] = null;
-        // Free heap paths buffer if any (but preserve count for toOwnedLengths)
-        if (!self.isInline()) {
-            self.allocator.free(self.heap_paths.?[0..self.capacity]);
-            self.heap_paths = null;
-        }
-        return buf;
-    }
+        const pathv_buf = try self.allocator.alloc([*c]u8, offs + count + 1);
+        errdefer self.allocator.free(pathv_buf);
+        const pathlen_buf = try self.allocator.alloc(usize, count + 2);
 
-    /// Transfer ownership of the lengths array (exact-sized allocation).
-    /// Note: count is NOT reset here; call deinit() when done with both arrays.
-    pub fn toOwnedLengths(self: *ResultsList) Allocator.Error![]usize {
-        const count = self.count;
-        // Always allocate exact-sized buffer and copy (simple + correct)
-        const buf = try self.allocator.alloc(usize, count);
-        if (count > 0) {
-            const src = self.lengthsPtr();
-            @memcpy(buf[0..count], src[0..count]);
+        @memset(pathv_buf[0..offs], null);
+        const base = self.bytes.items.ptr;
+        const offsets = self.offsetsPtr();
+        const lengths = self.lengthsPtr();
+        for (0..count) |i| {
+            pathv_buf[offs + i] = @ptrCast(base + offsets[i]);
+            pathlen_buf[i] = lengths[i];
         }
-        // Free heap lengths buffer if any
-        if (self.heap_lengths) |hl| {
-            self.allocator.free(hl[0..self.capacity]);
-            self.heap_lengths = null;
-        }
-        return buf;
+        pathv_buf[offs + count] = null;
+        pathlen_buf[count] = @intFromPtr(base);
+        pathlen_buf[count + 1] = self.bytes.capacity;
+
+        pzlob.zlo_pathc = count;
+        pzlob.zlo_pathv = @ptrCast(pathv_buf.ptr);
+        pzlob.zlo_pathlen = pathlen_buf.ptr;
+        pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
+
+        // The byte buffer now belongs to pzlob; deinit must not free it.
+        self.bytes = .empty;
     }
 };
+
+/// Emit a lone result path (NOCHECK pattern echo, literal path hit) in the
+/// format ResultsList.emit produces, so globfreeInternal can treat every
+/// OWNS_STRINGS zlob_t the same way.
+pub fn emitSingleResult(allocator: Allocator, pzlob: *zlob_t, path: []const u8, append_slash: bool) Allocator.Error!void {
+    var list = ResultsList.init(allocator);
+    defer list.deinit();
+    const total = path.len + @intFromBool(append_slash);
+    const dst = try list.addPath(total);
+    @memcpy(dst[0..path.len], path);
+    if (append_slash) dst[path.len] = '/';
+    try list.emit(0, pzlob);
+}
 
 const PatternInfo = struct {
     literal_prefix: []const u8, // e.g., "src/foo" from "src/foo/*.txt"
@@ -545,9 +548,26 @@ inline fn matchWithAlternativesExtglob(name: []const u8, alternatives: []const [
     return false;
 }
 
-inline fn matchWithAlternativesPrecomputedExtglob(name: []const u8, patterns: []const []const u8, contexts: []const PatternContext, enable_extglob: bool) bool {
-    for (patterns, contexts) |pat, *ctx| {
-        if (enable_extglob and fnmatch_impl.containsExtglob(pat)) {
+/// Bitmask of which alternatives contain extglob syntax, computed once per
+/// glob call. Alternatives past 64 fall back to a live scan in altIsExtglob.
+fn altExtglobMask(alternatives: anytype) u64 {
+    var mask: u64 = 0;
+    const alts = alternatives orelse return 0;
+    for (alts, 0..) |alt, i| {
+        if (i >= 64) break;
+        if (fnmatch_impl.containsExtglob(alt)) mask |= @as(u64, 1) << @intCast(i);
+    }
+    return mask;
+}
+
+inline fn altIsExtglob(mask: u64, i: usize, pattern: []const u8) bool {
+    if (i < 64) return (mask >> @intCast(i)) & 1 != 0;
+    return fnmatch_impl.containsExtglob(pattern);
+}
+
+inline fn matchWithAlternativesPrecomputedExtglob(name: []const u8, patterns: []const []const u8, contexts: []const PatternContext, extglob_mask: u64) bool {
+    for (patterns, contexts, 0..) |pat, *ctx, i| {
+        if (altIsExtglob(extglob_mask, i, pat)) {
             if (fnmatch_impl.matchExtglob(pat, name)) return true;
         } else {
             if (ctx.single_suffix_matcher) |*batched| {
@@ -567,7 +587,7 @@ fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const 
     // The main recursive and filtered paths handle gitignore
     _ = gitignore_filter;
 
-    var components: [64][]const u8 = undefined;
+    var components: [64]WildcardComponent = undefined;
     var component_count: usize = 0;
 
     const effective_pattern = info.wildcard_suffix;
@@ -576,14 +596,14 @@ fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const 
     for (effective_pattern, 0..) |ch, idx| {
         if (isSep(ch)) {
             if (idx > start) {
-                components[component_count] = effective_pattern[start..idx];
+                components[component_count] = WildcardComponent.init(effective_pattern[start..idx], flags);
                 component_count += 1;
             }
             start = idx + 1;
         }
     }
     if (start < effective_pattern.len) {
-        components[component_count] = effective_pattern[start..];
+        components[component_count] = WildcardComponent.init(effective_pattern[start..], flags);
         component_count += 1;
     }
 
@@ -596,38 +616,16 @@ fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const 
 
     var result_paths = ResultsList.initWithCapacity(allocator, estimated_capacity) catch ResultsList.init(allocator);
     defer result_paths.deinit();
-    errdefer {
-        for (result_paths.pathSlice(), result_paths.lengthSlice()) |path, path_len| {
-            const path_slice = @as([*]u8, @ptrCast(path))[0 .. path_len + 1];
-            allocator.free(path_slice);
-        }
-    }
-
     const start_dir = if (info.literal_prefix.len > 0)
         info.literal_prefix
     else
         ".";
 
-    try expandWildcardComponents(allocator, start_dir, components[0..component_count], 0, &result_paths, directories_only, flags, errfunc, io, base_dir, fs_provider);
+    try expandWildcardComponents(allocator, start_dir, components[0..component_count], 0, &result_paths, directories_only, flags, errfunc, io, base_dir, fs_provider, base_dir, start_dir);
 
     if (result_paths.len() == 0) {
         if (flags.nocheck) {
-            const pat_copy = allocator.allocSentinel(u8, pattern.len, 0) catch return error.OutOfMemory;
-            @memcpy(pat_copy[0..pattern.len], pattern);
-            const path: [*c]u8 = @ptrCast(pat_copy.ptr);
-
-            const pathv_buf = allocator.alloc([*c]u8, 2) catch return error.OutOfMemory;
-            const result: [*c][*c]u8 = @ptrCast(pathv_buf.ptr);
-            result[0] = path;
-            result[1] = null;
-
-            const pathlen_buf = allocator.alloc(usize, 1) catch return error.OutOfMemory;
-            pathlen_buf[0] = pattern.len;
-
-            pzlob.zlo_pathc = 1;
-            pzlob.zlo_pathv = result;
-            pzlob.zlo_pathlen = pathlen_buf.ptr;
-            pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
+            emitSingleResult(allocator, pzlob, pattern, false) catch return error.OutOfMemory;
             return;
         }
         return null;
@@ -636,10 +634,31 @@ fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const 
     return finalizeResults(allocator, &result_paths, flags, pzlob);
 }
 
+/// One path component of a wildcard-dirs pattern, with its match state
+/// precomputed: expandWildcardComponents matches the same component against
+/// every directory it visits.
+const WildcardComponent = struct {
+    text: []const u8,
+    ctx: PatternContext,
+    /// flags.extglob AND the component contains extglob syntax
+    is_extglob: bool,
+
+    fn init(text: []const u8, flags: ZlobFlags) WildcardComponent {
+        return .{
+            .text = text,
+            .ctx = PatternContext.init(text),
+            .is_extglob = flags.extglob and fnmatch_impl.containsExtglob(text),
+        };
+    }
+};
+
+/// `current_dir` is the full path from the walk root, used for results and
+/// error reporting. `(rel_base, rel_path)` names the same directory relative
+/// to an already-open ancestor fd where the platform offers one.
 fn expandWildcardComponents(
     allocator: std.mem.Allocator,
     current_dir: []const u8,
-    components: []const []const u8,
+    components: []const WildcardComponent,
     component_idx: usize,
     results: *ResultsList,
     directories_only: bool,
@@ -648,6 +667,8 @@ fn expandWildcardComponents(
     io: Io,
     base_dir: ?std.Io.Dir,
     fs_provider: walker.AltFs,
+    rel_base: ?std.Io.Dir,
+    rel_path: []const u8,
 ) !void {
     if (component_idx > 65536) {
         @branchHint(.unlikely);
@@ -658,19 +679,15 @@ fn expandWildcardComponents(
     if (component_idx >= components.len) {
         @branchHint(.unlikely);
 
-        const path_copy = try allocator.allocSentinel(u8, current_dir.len, 0);
-        @memcpy(path_copy[0..current_dir.len], current_dir);
-        const path: [*c]u8 = @ptrCast(path_copy.ptr);
-        try results.append(path, current_dir.len);
+        try results.appendPath(current_dir);
         return;
     }
 
-    const component = components[component_idx];
+    const component = &components[component_idx];
     const is_final = component_idx == components.len - 1;
 
-    const component_ctx = PatternContext.init(component);
-    const enable_extglob = flags.extglob;
-    const has_extglob_pattern = enable_extglob and fnmatch_impl.containsExtglob(component);
+    const component_ctx = &component.ctx;
+    const has_extglob_pattern = component.is_extglob;
     const needs_wildcard_matching = component_ctx.has_wildcards or has_extglob_pattern;
 
     if (needs_wildcard_matching) {
@@ -680,51 +697,88 @@ fn expandWildcardComponents(
             flags.period,
         );
 
-        var iter = walker.DirIterator.openHandled(io, current_dir, base_dir, hidden_config, fs_provider, .{
+        var iter: walker.DirIterator = undefined;
+        const opened = walker.DirIterator.openHandledInto(&iter, io, rel_path, rel_base, hidden_config, fs_provider, .{
             .err_callback = errfunc,
             .abort_on_error = flags.err,
+            .report_path = current_dir,
         }) catch return error.Aborted;
-        if (iter == null) return;
-        defer iter.?.close();
+        if (!opened) return;
+        defer iter.close();
 
-        while (iter.?.next()) |entry| {
+        const child_base = iter.relativeBase();
+
+        while (iter.next()) |entry| {
             const name = entry.name;
             if (!is_final and entry.kind != .directory) continue;
 
             const matches = if (has_extglob_pattern) blk: {
-                break :blk fnmatch_impl.matchExtglob(component, name);
+                break :blk fnmatch_impl.matchExtglob(component.text, name);
             } else if (is_final and component_ctx.single_suffix_matcher != null)
                 component_ctx.single_suffix_matcher.?.matchSuffix(name)
             else
-                fnmatch_impl.fnmatchWithContext(&component_ctx, name, .{});
+                fnmatch_impl.fnmatchWithContext(component_ctx, name, .{});
 
             if (matches) {
-                if (is_final and directories_only and entry.kind != .directory) continue;
+                if (is_final) {
+                    if (directories_only and entry.kind != .directory) continue;
+                    // Build "dir/name" straight into the results buffer;
+                    // recursing would stage it in a stack buffer first.
+                    const use_dir = current_dir.len > 0 and !mem.eql(u8, current_dir, ".");
+                    const total_len = if (use_dir) current_dir.len + 1 + name.len else name.len;
+                    if (total_len >= 4096) continue;
+                    const dst = try results.addPath(total_len);
+                    if (use_dir) {
+                        @memcpy(dst[0..current_dir.len], current_dir);
+                        dst[current_dir.len] = '/';
+                        @memcpy(dst[current_dir.len + 1 ..][0..name.len], name);
+                    } else {
+                        @memcpy(dst[0..name.len], name);
+                    }
+                    continue;
+                }
 
                 var new_path_buf: [4096]u8 = undefined;
                 const new_path = buildPathInBuffer(&new_path_buf, current_dir, name);
                 if (new_path.len >= 4096) continue;
 
-                try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider);
+                if (child_base) |cb| {
+                    try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider, cb, name);
+                } else {
+                    var rel_buf: [4096]u8 = undefined;
+                    const new_rel = if (rel_path.len == current_dir.len and rel_path.ptr == current_dir.ptr)
+                        new_path
+                    else
+                        buildPathInBuffer(&rel_buf, rel_path, name);
+                    if (new_rel.len >= 4096) continue;
+                    try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider, rel_base, new_rel);
+                }
             }
         }
     } else {
         // Literal component - just check if it exists
         var new_path_buf: [4096]u8 = undefined;
-        const new_path = buildPathInBuffer(&new_path_buf, current_dir, component);
+        const new_path = buildPathInBuffer(&new_path_buf, current_dir, component.text);
 
         if (new_path.len >= 4096) return;
+
+        var rel_buf: [4096]u8 = undefined;
+        const new_rel = if (rel_path.len == current_dir.len and rel_path.ptr == current_dir.ptr)
+            new_path
+        else
+            buildPathInBuffer(&rel_buf, rel_path, component.text);
+        if (new_rel.len >= 4096) return;
 
         if (!is_final) {
             // For non-final literal components, skip the stat() syscall entirely.
             // Just try to recurse - if the path doesn't exist, the next opendir will fail gracefully.
-            try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider);
+            try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider, rel_base, new_rel);
         } else {
             // For final component, we need stat to check existence and directory-ness
-            const root = base_dir orelse std.Io.Dir.cwd();
-            const stat = root.statFile(io, new_path, .{}) catch return;
+            const root = rel_base orelse std.Io.Dir.cwd();
+            const stat = root.statFile(io, new_rel, .{}) catch return;
             if (directories_only and stat.kind != .directory) return;
-            try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider);
+            try expandWildcardComponents(allocator, new_path, components, component_idx + 1, results, directories_only, flags, errfunc, io, base_dir, fs_provider, rel_base, new_rel);
         }
     }
 }
@@ -919,22 +973,7 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
 }
 
 fn returnPatternAsResult(allocator: std.mem.Allocator, pattern: []const u8, pzlob: *zlob_t) !?void {
-    const path_copy = try allocator.allocSentinel(u8, pattern.len, 0);
-    @memcpy(path_copy[0..pattern.len], pattern);
-    const path: [*c]u8 = @ptrCast(path_copy.ptr);
-
-    const pathv_buf = try allocator.alloc([*c]u8, 2);
-    const result: [*c][*c]u8 = @ptrCast(pathv_buf.ptr);
-    result[0] = path;
-    result[1] = null;
-
-    const pathlen_buf = try allocator.alloc(usize, 1);
-    pathlen_buf[0] = pattern.len;
-
-    pzlob.zlo_pathc = 1;
-    pzlob.zlo_pathv = result;
-    pzlob.zlo_pathlen = pathlen_buf.ptr;
-    pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
+    try emitSingleResult(allocator, pzlob, pattern, false);
     return;
 }
 
@@ -1098,38 +1137,20 @@ fn globBraceExpand(allocator: std.mem.Allocator, pattern: []const u8, flags: Zlo
 
         _ = try globSingle(allocator, exp_slice, null, flags.without(.{ .append = true }), errfunc, &temp_pzlob, gitignore_filter, io, base_dir, fs_provider);
 
-        // Collect results from temp_pzlob
+        // Copy each path's bytes into the shared buffer, then release the
+        // sub-glob's result set.
         if (temp_pzlob.zlo_pathc > 0) {
             for (0..temp_pzlob.zlo_pathc) |i| {
-                try all_results.append(temp_pzlob.zlo_pathv[i], temp_pzlob.zlo_pathlen[i]);
+                const path_ptr: [*]const u8 = @ptrCast(temp_pzlob.zlo_pathv[i]);
+                try all_results.appendPath(path_ptr[0..temp_pzlob.zlo_pathlen[i]]);
             }
-            // Don't free the paths yet, we're transferring ownership
-            // Free the pathv array and pathlen array, but not the paths themselves
-            if (temp_pzlob.zlo_flags & ZLOB_FLAGS_OWNS_STRINGS != 0) {
-                allocator.free(@as([*]const [*c]u8, @ptrCast(temp_pzlob.zlo_pathv))[0 .. temp_pzlob.zlo_pathc + 1]);
-                allocator.free(@as([*]const usize, @ptrCast(temp_pzlob.zlo_pathlen))[0..temp_pzlob.zlo_pathc]);
-            }
+            globfreeInternal(allocator, &temp_pzlob);
         }
     }
 
     if (all_results.len() == 0) {
         if (flags.nocheck) {
-            const pat_copy = try allocator.allocSentinel(u8, pattern.len, 0);
-            @memcpy(pat_copy[0..pattern.len], pattern);
-            const path: [*c]u8 = @ptrCast(pat_copy.ptr);
-
-            const pathv_buf = try allocator.alloc([*c]u8, 2);
-            const result: [*c][*c]u8 = @ptrCast(pathv_buf.ptr);
-            result[0] = path;
-            result[1] = null;
-
-            const pathlen_buf = try allocator.alloc(usize, 1);
-            pathlen_buf[0] = pattern.len;
-
-            pzlob.zlo_pathc = 1;
-            pzlob.zlo_pathv = result;
-            pzlob.zlo_pathlen = pathlen_buf.ptr;
-            pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
+            try emitSingleResult(allocator, pzlob, pattern, false);
             return;
         }
         return null;
@@ -1137,21 +1158,12 @@ fn globBraceExpand(allocator: std.mem.Allocator, pattern: []const u8, flags: Zlo
 
     const count = all_results.len();
 
-    // Transfer ownership directly from ResultsList - avoids allocation and copy
-    const pathv_buf = try all_results.toOwnedPathv();
-    const pathlen_buf = try all_results.toOwnedLengths();
-
-    const result: [*c][*c]u8 = @ptrCast(pathv_buf.ptr);
+    try all_results.emit(0, pzlob);
 
     // Sort using pre-computed lengths - no strlen() calls!
     if (!flags.nosort) {
-        sorting.sortPaths(@ptrCast(result), pathlen_buf.ptr, count);
+        sorting.sortPaths(@ptrCast(pzlob.zlo_pathv), pzlob.zlo_pathlen, count);
     }
-
-    pzlob.zlo_pathc = count;
-    pzlob.zlo_pathv = result;
-    pzlob.zlo_pathlen = pathlen_buf.ptr;
-    pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
     return;
 }
 
@@ -1496,9 +1508,7 @@ fn globWithBracedComponents(
         // No wildcard components - just verify path exists and add it
         const root = base_dir orelse std.Io.Dir.cwd();
         _ = root.statFile(io, start_dir, .{}) catch return null;
-        const path_copy = try allocator.allocSentinel(u8, start_dir.len, 0);
-        @memcpy(path_copy[0..start_dir.len], start_dir);
-        try all_results.append(@ptrCast(path_copy.ptr), start_dir.len);
+        try all_results.appendPath(start_dir);
         return finalizeResults(allocator, &all_results, flags, pzlob);
     }
 
@@ -1524,9 +1534,8 @@ fn globWithBracedComponents(
         fs_provider,
         struct {
             fn onComplete(alloc: std.mem.Allocator, path: []const u8, results: *ResultsList, _: bool) !void {
-                const path_copy = try alloc.allocSentinel(u8, path.len, 0);
-                @memcpy(path_copy[0..path.len], path);
-                try results.append(@ptrCast(path_copy.ptr), path.len);
+                _ = alloc;
+                try results.appendPath(path);
             }
         }.onComplete,
     );
@@ -1543,17 +1552,23 @@ const BracedComponentMatcher = struct {
     text: []const u8,
     alternatives: ?[]const []const u8,
     is_last: bool,
+    /// Precomputed once per matcher, since matchesWithFlags runs per entry.
+    ctx: PatternContext,
+    /// text contains extglob syntax (flag-independent; gate with the flag)
+    has_extglob: bool,
 
     fn fromBracedComponent(comp: *const brace_optimizer.BracedComponent) BracedComponentMatcher {
-        return .{
-            .text = comp.text,
-            .alternatives = comp.alternatives,
-            .is_last = comp.is_last,
-        };
+        return fromTextAndAlts(comp.text, comp.alternatives, comp.is_last);
     }
 
     fn fromTextAndAlts(text: []const u8, alts: ?[]const []const u8, is_last: bool) BracedComponentMatcher {
-        return .{ .text = text, .alternatives = alts, .is_last = is_last };
+        return .{
+            .text = text,
+            .alternatives = alts,
+            .is_last = is_last,
+            .ctx = PatternContext.init(text),
+            .has_extglob = fnmatch_impl.containsExtglob(text),
+        };
     }
 
     /// Check if name matches this component
@@ -1566,12 +1581,10 @@ const BracedComponentMatcher = struct {
         if (self.alternatives) |alts| {
             return matchWithAlternativesExtglob(name, alts, enable_extglob);
         }
-        // Check for extglob pattern
-        if (enable_extglob and fnmatch_impl.containsExtglob(self.text)) {
+        if (enable_extglob and self.has_extglob) {
             return fnmatch_impl.matchExtglob(self.text, name);
         }
-        const ctx = PatternContext.init(self.text);
-        return fnmatch_impl.fnmatchWithContext(&ctx, name, .{});
+        return fnmatch_impl.fnmatchWithContext(&self.ctx, name, .{});
     }
 
     /// Check if any pattern/alternative starts with dot
@@ -1617,14 +1630,15 @@ fn walkBracedComponents(
     };
 
     // Use walker's DirIterator with FsProvider for ALTDIRFUNC support
-    var iter = walker.DirIterator.openHandled(io, current_dir, base_dir, hidden_config, fs_provider, .{
+    var iter: walker.DirIterator = undefined;
+    const opened = walker.DirIterator.openHandledInto(&iter, io, current_dir, base_dir, hidden_config, fs_provider, .{
         .err_callback = errfunc,
         .abort_on_error = flags.err,
     }) catch return error.Aborted;
-    if (iter == null) return;
-    defer iter.?.close();
+    if (!opened) return;
+    defer iter.close();
 
-    while (iter.?.next()) |entry| {
+    while (iter.next()) |entry| {
         // Note: Hidden file filtering is now done at iterator level
         if (!is_final and entry.kind != .directory) continue;
 
@@ -1690,14 +1704,15 @@ fn globRecursiveWithBracedPrefix(
     };
 
     // Use walker's DirIterator with FsProvider for ALTDIRFUNC support
-    var iter = walker.DirIterator.openHandled(io, current_dir, base_dir, hidden_config, fs_provider, .{
+    var iter: walker.DirIterator = undefined;
+    const opened = walker.DirIterator.openHandledInto(&iter, io, current_dir, base_dir, hidden_config, fs_provider, .{
         .err_callback = errfunc,
         .abort_on_error = flags.err,
     }) catch return error.Aborted;
-    if (iter == null) return;
-    defer iter.?.close();
+    if (!opened) return;
+    defer iter.close();
 
-    while (iter.?.next()) |entry| {
+    while (iter.next()) |entry| {
         // Note: Hidden file filtering is now done at iterator level
         if (entry.kind != .directory) continue;
 
@@ -1729,74 +1744,41 @@ fn finalizeResults(allocator: std.mem.Allocator, results: *ResultsList, flags: Z
     const offs = if (flags.dooffs) pzlob.zlo_offs else 0;
     const new_count = results.len();
 
-    // ZLOB_APPEND - merge with existing results
+    // ZLOB_APPEND - merge with existing results. The emit format keeps all
+    // owned strings in one buffer, so import the old set's bytes then the new
+    // ones and release the old result set wholesale.
     if (flags.append and pzlob.zlo_pathv != null and pzlob.zlo_pathc > 0) {
         const old_count = pzlob.zlo_pathc;
-        const total_count = old_count + new_count;
 
-        const pathv_buf = allocator.alloc([*c]u8, offs + total_count + 1) catch return error.OutOfMemory;
-        const pathlen_buf = allocator.alloc(usize, total_count) catch return error.OutOfMemory;
+        var combined = try ResultsList.initWithCapacity(allocator, old_count + new_count);
+        defer combined.deinit();
 
-        @memset(pathv_buf[0..offs], null);
+        for (0..old_count) |i| {
+            const path_ptr: [*]const u8 = @ptrCast(pzlob.zlo_pathv[offs + i]);
+            try combined.appendPath(path_ptr[0..pzlob.zlo_pathlen[i]]);
+        }
+        for (0..new_count) |i| {
+            try combined.appendPath(results.getPath(i));
+        }
 
-        const old_pathv = @as([*][*c]u8, @ptrCast(pzlob.zlo_pathv))[offs..][0..old_count];
-        @memcpy(pathv_buf[offs..][0..old_count], old_pathv);
-        @memcpy(pathlen_buf[0..old_count], pzlob.zlo_pathlen[0..old_count]);
-        @memcpy(pathv_buf[offs + old_count ..][0..new_count], results.pathSlice());
-        @memcpy(pathlen_buf[old_count..][0..new_count], results.lengthSlice());
+        // Frees the old arrays and, when owned, the old byte buffer.
+        // Leaves zlo_offs alone for the emit() below.
+        globfreeInternal(allocator, pzlob);
 
-        pathv_buf[offs + total_count] = null;
-        const result: [*c][*c]u8 = @ptrCast(pathv_buf.ptr);
-
-        // Free old arrays
-        const old_pathv_slice = @as([*][*c]u8, @ptrCast(pzlob.zlo_pathv))[0 .. offs + old_count + 1];
-        allocator.free(old_pathv_slice);
-        const old_pathlen_slice = pzlob.zlo_pathlen[0..old_count];
-        allocator.free(old_pathlen_slice);
-
-        pzlob.zlo_pathc = total_count;
-        pzlob.zlo_pathv = result;
-        pzlob.zlo_pathlen = pathlen_buf.ptr;
-        pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
+        try combined.emit(offs, pzlob);
 
         if (!flags.nosort and new_count > 0) {
-            sorting.sortPaths(@ptrCast(result + offs + old_count), pathlen_buf.ptr + old_count, new_count);
+            sorting.sortPaths(@ptrCast(pzlob.zlo_pathv + offs + old_count), pzlob.zlo_pathlen + old_count, new_count);
         }
-    } else if (offs == 0) {
-        // Fast path: no offset slots needed, transfer ownership directly from ResultsList
-        // This avoids allocating new buffers and copying data (just shrinks to exact size)
-        const pathv_buf = results.toOwnedPathv() catch return error.OutOfMemory;
-        const pathlen_buf = results.toOwnedLengths() catch return error.OutOfMemory;
-
-        pzlob.zlo_pathc = new_count;
-        pzlob.zlo_pathv = @ptrCast(pathv_buf.ptr);
-        pzlob.zlo_pathlen = pathlen_buf.ptr;
-        pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
-
-        if (!flags.nosort) {
-            sorting.sortPaths(@ptrCast(pzlob.zlo_pathv), pathlen_buf.ptr, new_count);
-        }
-    } else {
-        // ZLOB_DOOFFS: need offset slots at the beginning, must allocate fresh buffers
-        const pathv_buf = allocator.alloc([*c]u8, offs + new_count + 1) catch return error.OutOfMemory;
-        const pathlen_buf = allocator.alloc(usize, new_count) catch return error.OutOfMemory;
-
-        @memset(pathv_buf[0..offs], null);
-        @memcpy(pathv_buf[offs..][0..new_count], results.pathSlice());
-        @memcpy(pathlen_buf, results.lengthSlice());
-
-        pathv_buf[offs + new_count] = null;
-        const result: [*c][*c]u8 = @ptrCast(pathv_buf.ptr);
-
-        pzlob.zlo_pathc = new_count;
-        pzlob.zlo_pathv = result;
-        pzlob.zlo_pathlen = pathlen_buf.ptr;
-        pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
-
-        if (!flags.nosort) {
-            sorting.sortPaths(@ptrCast(result + offs), pathlen_buf.ptr, new_count);
-        }
+        return;
     }
+
+    try results.emit(offs, pzlob);
+
+    if (!flags.nosort) {
+        sorting.sortPaths(@ptrCast(pzlob.zlo_pathv + offs), pzlob.zlo_pathlen, new_count);
+    }
+    return;
 }
 
 fn globRecursiveWalk(
@@ -1815,6 +1797,9 @@ fn globRecursiveWalk(
 
     const pattern_ctx = PatternContext.init(rec_pattern.file_pattern);
     const enable_extglob = flags.extglob;
+    // Loop-invariant, so keep it out of the per-entry match chain below.
+    const file_pattern_is_extglob = enable_extglob and fnmatch_impl.containsExtglob(rec_pattern.file_pattern);
+    const file_alt_extglob_mask: u64 = if (enable_extglob) altExtglobMask(rec_pattern.file_alternatives) else 0;
 
     var dir_component_contexts: [32]PatternContext = undefined;
     if (has_dir_components) {
@@ -1898,13 +1883,13 @@ fn globRecursiveWalk(
 
         const matches = if (rec_pattern.file_pattern_contexts) |contexts| blk: {
             if (enable_extglob and rec_pattern.file_alternatives != null) {
-                break :blk matchWithAlternativesPrecomputedExtglob(entry.basename, rec_pattern.file_alternatives.?, contexts, true);
+                break :blk matchWithAlternativesPrecomputedExtglob(entry.basename, rec_pattern.file_alternatives.?, contexts, file_alt_extglob_mask);
             }
             const multi_suffix_ptr = if (rec_pattern.multi_suffix_matcher) |*ms| ms else null;
             break :blk matchWithAlternativesPrecomputed(entry.basename, contexts, multi_suffix_ptr);
         } else if (rec_pattern.file_alternatives) |alts|
             matchWithAlternativesExtglob(entry.basename, alts, enable_extglob)
-        else if (enable_extglob and fnmatch_impl.containsExtglob(rec_pattern.file_pattern)) blk: {
+        else if (file_pattern_is_extglob) blk: {
             break :blk fnmatch_impl.matchExtglob(rec_pattern.file_pattern, entry.basename);
         } else if (pattern_ctx.single_suffix_matcher) |sufxi_matcher|
             sufxi_matcher.matchSuffix(entry.basename)
@@ -1914,12 +1899,12 @@ fn globRecursiveWalk(
         if (matches) {
             if (info.directories_only and !is_dir) continue;
 
-            // Build full path
+            // Build full path directly in the results' shared byte buffer
             const needs_mark = flags.mark and is_dir;
             const base_path_len = if (use_dirname) start_dir.len + 1 + entry.path.len else entry.path.len;
             const alloc_len = if (needs_mark) base_path_len + 1 else base_path_len;
 
-            const path_buf = allocator.allocSentinel(u8, alloc_len, 0) catch return error.OutOfMemory;
+            const path_buf = results.addPath(alloc_len) catch return error.OutOfMemory;
 
             if (use_dirname) {
                 @memcpy(path_buf[0..start_dir.len], start_dir);
@@ -1929,12 +1914,9 @@ fn globRecursiveWalk(
                 @memcpy(path_buf[0..entry.path.len], entry.path);
             }
 
-            const final_len = if (needs_mark) blk: {
+            if (needs_mark) {
                 path_buf[base_path_len] = '/';
-                break :blk base_path_len + 1;
-            } else base_path_len;
-
-            results.append(@ptrCast(path_buf.ptr), final_len) catch return error.OutOfMemory;
+            }
         }
     }
 }
@@ -2000,9 +1982,6 @@ fn matchDirComponents(
     return true;
 }
 
-pub const PathBuildResult = utils.PathBuildResult;
-const buildFullPathWithMark = utils.buildFullPathWithMark;
-
 fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8, dirname: []const u8, flags: ZlobFlags, errfunc: zlob_errfunc_t, pzlob: *zlob_t, directories_only: bool, gitignore_filter: ?*GitIgnore, brace_parsed: ?*const brace_optimizer.BracedPattern, io: Io, base_dir: ?std.Io.Dir, fs_provider: walker.AltFs) !?void {
     // If we have brace alternatives for the filename pattern, use them for matching
     // e.g., "*.{toml,lock}" -> alternatives = ["*.toml", "*.lock"]
@@ -2031,6 +2010,9 @@ fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8,
     const pattern_ctx = PatternContext.init(pattern);
     const use_dirname = dirname.len > 0 and !mem.eql(u8, dirname, ".");
     const enable_extglob = flags.extglob;
+    // Loop-invariant, so keep it out of the per-entry match chain below.
+    const pattern_is_extglob = enable_extglob and fnmatch_impl.containsExtglob(pattern);
+    const alt_extglob_mask: u64 = if (enable_extglob) altExtglobMask(file_pattern_alts) else 0;
 
     var names = ResultsList.initWithCapacity(allocator, 256) catch ResultsList.init(allocator);
     defer names.deinit();
@@ -2043,22 +2025,23 @@ fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8,
     );
 
     // Use walker's DirIterator with FsProvider for ALTDIRFUNC support
-    var iter = walker.DirIterator.openHandled(io, dirname, base_dir, hidden_config, fs_provider, .{
+    var iter: walker.DirIterator = undefined;
+    const opened = walker.DirIterator.openHandledInto(&iter, io, dirname, base_dir, hidden_config, fs_provider, .{
         .err_callback = errfunc,
         .abort_on_error = flags.err,
     }) catch return error.Aborted;
-    if (iter == null) return null;
-    defer iter.?.close();
+    if (!opened) return null;
+    defer iter.close();
 
-    while (iter.?.next()) |entry| {
+    while (iter.next()) |entry| {
         const name = entry.name;
         // Note: Hidden file and dot entry filtering is now done at iterator level
 
         const matches = if (file_alternatives) |alts| blk: {
             // Check if we should use extglob matching
             if (enable_extglob and file_pattern_alts != null) {
-                for (file_pattern_alts.?, alts) |raw_pat, alt_ctx| {
-                    if (fnmatch_impl.containsExtglob(raw_pat)) {
+                for (file_pattern_alts.?, alts, 0..) |raw_pat, alt_ctx, alt_i| {
+                    if (altIsExtglob(alt_extglob_mask, alt_i, raw_pat)) {
                         if (fnmatch_impl.matchExtglob(raw_pat, name)) break :blk true;
                     } else if (alt_ctx.single_suffix_matcher) |batched_suffix_match| {
                         if (batched_suffix_match.matchSuffix(name)) break :blk true;
@@ -2076,7 +2059,7 @@ fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8,
                 }
             }
             break :blk false;
-        } else if (enable_extglob and fnmatch_impl.containsExtglob(pattern)) blk: {
+        } else if (pattern_is_extglob) blk: {
             break :blk fnmatch_impl.matchExtglob(pattern, name);
         } else if (pattern_ctx.single_suffix_matcher) |batched_suffix_match|
             batched_suffix_match.matchSuffix(name)
@@ -2087,40 +2070,37 @@ fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8,
             const is_dir = entry.kind == .directory;
             if (directories_only and !is_dir) continue;
 
-            // Use optimized path builder that pre-allocates for trailing slash
-            const path_result = buildFullPathWithMark(allocator, dirname, name, use_dirname, is_dir, flags) catch return error.OutOfMemory;
+            // Build the path directly in the results' shared byte buffer,
+            // pre-sized for an optional trailing '/' mark
+            const base_len = if (use_dirname) dirname.len + 1 + name.len else name.len;
+            const needs_mark = flags.mark and is_dir;
+            const alloc_len = if (needs_mark) base_len + 1 else base_len;
+
+            const dst = names.addPath(alloc_len) catch return error.OutOfMemory;
+            if (use_dirname) {
+                @memcpy(dst[0..dirname.len], dirname);
+                dst[dirname.len] = '/';
+                @memcpy(dst[dirname.len + 1 ..][0..name.len], name);
+            } else {
+                @memcpy(dst[0..name.len], name);
+            }
+            if (needs_mark) {
+                dst[base_len] = '/';
+            }
 
             if (gitignore_filter) |gi| {
-                const base_len = if (use_dirname) dirname.len + 1 + name.len else name.len;
-                const relative_path = if (use_dirname) path_result.buf[0..base_len] else name;
+                const relative_path = if (use_dirname) dst[0..base_len] else name;
                 if (gi.isIgnored(relative_path, is_dir)) {
-                    allocator.free(path_result.buf);
+                    names.discardLast();
                     continue;
                 }
             }
-
-            names.append(path_result.ptr, path_result.len) catch return error.OutOfMemory;
         }
     }
 
     if (names.len() == 0) {
         if (flags.nocheck) {
-            const pat_copy = allocator.allocSentinel(u8, pattern.len, 0) catch return error.OutOfMemory;
-            @memcpy(pat_copy[0..pattern.len], pattern);
-            const path: [*c]u8 = @ptrCast(pat_copy.ptr);
-
-            const pathv_buf = allocator.alloc([*c]u8, 2) catch return error.OutOfMemory;
-            const result: [*c][*c]u8 = @ptrCast(pathv_buf.ptr);
-            result[0] = path;
-            result[1] = null;
-
-            const pathlen_buf = allocator.alloc(usize, 1) catch return error.OutOfMemory;
-            pathlen_buf[0] = pattern.len;
-
-            pzlob.zlo_pathc = 1;
-            pzlob.zlo_pathv = result;
-            pzlob.zlo_pathlen = pathlen_buf.ptr;
-            pzlob.zlo_flags = ZLOB_FLAGS_OWNS_STRINGS;
+            emitSingleResult(allocator, pzlob, pattern, false) catch return error.OutOfMemory;
             return;
         }
         return null;
@@ -2239,22 +2219,21 @@ pub fn globfreeInternal(allocator: std.mem.Allocator, pzlob: *zlob_t) void {
         const owns_strings = (pzlob.zlo_flags & ZLOB_FLAGS_OWNS_STRINGS) != 0;
 
         if (owns_strings) {
-            var i: usize = 0;
-            while (i < pzlob.zlo_pathc) : (i += 1) {
-                if (pathv[offs + i]) |path| {
-                    const path_len = pzlob.zlo_pathlen[i];
-                    const path_slice = @as([*]u8, @ptrCast(path))[0 .. path_len + 1];
-                    allocator.free(path_slice);
-                }
+            // Owned strings share one buffer, whose base and capacity sit in
+            // the two slots past the visible lengths. See ResultsList.emit.
+            const base_addr = pzlob.zlo_pathlen[pzlob.zlo_pathc];
+            const buf_cap = pzlob.zlo_pathlen[pzlob.zlo_pathc + 1];
+            if (buf_cap > 0) {
+                allocator.free(@as([*]u8, @ptrFromInt(base_addr))[0..buf_cap]);
             }
         }
         // Always free the pathv array including offset slots
         const pathv_slice = @as([*][*c]u8, @ptrCast(pathv))[0 .. offs + pzlob.zlo_pathc + 1];
         allocator.free(pathv_slice);
 
-        // Always free the pathlen array
-        const pathlen_slice = pzlob.zlo_pathlen[0..pzlob.zlo_pathc];
-        allocator.free(pathlen_slice);
+        // Free the pathlen array; owned results carry the two extra slots.
+        const pathlen_extra: usize = if (owns_strings) 2 else 0;
+        allocator.free(pzlob.zlo_pathlen[0 .. pzlob.zlo_pathc + pathlen_extra]);
     }
     pzlob.zlo_pathv = null;
     pzlob.zlo_pathc = 0;

--- a/src/zlob.zig
+++ b/src/zlob.zig
@@ -176,7 +176,7 @@ fn globLiteralPath(allocator: Allocator, path: []const u8, flags: ZlobFlags, pzl
     }
 
     const needs_slash = flags.mark and is_dir;
-    try emitSingleResult(allocator, pzlob, return_path, needs_slash);
+    try ResultsList.emitSingle(allocator, pzlob, dooffsSlots(flags, pzlob), return_path, needs_slash);
 
     return true;
 }
@@ -327,15 +327,8 @@ pub const ResultsList = struct {
         return self.bytes.items[self.offsetsPtr()[i]..][0..self.lengthsPtr()[i]];
     }
 
-    /// Emit the collected results into `pzlob`:
-    ///   pathv:   [offs nulls][count pointers][null]         (offs+count+1 slots)
-    ///   pathlen: [count lengths][bytes base][bytes capacity] (count+2 slots)
-    /// Ownership of the byte buffer moves into the zlob_t, and the two slots
-    /// past the visible lengths let globfreeInternal release the whole result
-    /// set in three frees. They are invisible to C callers, which only ever
-    /// see zlo_pathlen as a pointer.
-    /// On error the list is unchanged and still safe to deinit.
-    pub fn emit(self: *ResultsList, offs: usize, pzlob: *zlob_t) Allocator.Error!void {
+    /// Emit the collected results into `pzlob`
+    fn emit(self: *ResultsList, offs: usize, pzlob: *zlob_t) Allocator.Error!void {
         const count = self.count;
         const pathv_buf = try self.allocator.alloc([*c]u8, offs + count + 1);
         errdefer self.allocator.free(pathv_buf);
@@ -361,19 +354,26 @@ pub const ResultsList = struct {
         // The byte buffer now belongs to pzlob; deinit must not free it.
         self.bytes = .empty;
     }
+
+    /// `offs` is the ZLOB_DOOFFS reserved-slot count, threaded through so a
+    /// lone result reserves them just like a full result set does.
+    pub fn emitSingle(allocator: Allocator, pzlob: *zlob_t, offs: usize, path: []const u8, append_slash: bool) Allocator.Error!void {
+        var list = ResultsList.init(allocator);
+        defer list.deinit(); // we move the ownership in the last line of list.emit
+        const total = path.len + @intFromBool(append_slash);
+        const dst = try list.addPath(total);
+        @memcpy(dst[0..path.len], path);
+
+        if (append_slash) dst[path.len] = '/';
+        try list.emit(offs, pzlob); // moves list into pzlob
+    }
 };
 
-/// Emit a lone result path (NOCHECK pattern echo, literal path hit) in the
-/// format ResultsList.emit produces, so globfreeInternal can treat every
-/// OWNS_STRINGS zlob_t the same way.
-pub fn emitSingleResult(allocator: Allocator, pzlob: *zlob_t, path: []const u8, append_slash: bool) Allocator.Error!void {
-    var list = ResultsList.init(allocator);
-    defer list.deinit();
-    const total = path.len + @intFromBool(append_slash);
-    const dst = try list.addPath(total);
-    @memcpy(dst[0..path.len], path);
-    if (append_slash) dst[path.len] = '/';
-    try list.emit(0, pzlob);
+/// Leading pathv slots reserved by ZLOB_DOOFFS. Every path that fills a
+/// zlob_t must honour this: callers index results from pathv[offs], and
+/// globfreeInternal sizes its free off zlo_offs no matter which path ran.
+inline fn dooffsSlots(flags: ZlobFlags, pzlob: *const zlob_t) usize {
+    return if (flags.dooffs) pzlob.zlo_offs else 0;
 }
 
 const PatternInfo = struct {
@@ -587,24 +587,46 @@ fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const 
     // The main recursive and filtered paths handle gitignore
     _ = gitignore_filter;
 
-    var components: [64]WildcardComponent = undefined;
-    var component_count: usize = 0;
-
     const effective_pattern = info.wildcard_suffix;
 
-    var start: usize = 0;
-    for (effective_pattern, 0..) |ch, idx| {
-        if (isSep(ch)) {
-            if (idx > start) {
-                components[component_count] = WildcardComponent.init(effective_pattern[start..idx], flags);
-                component_count += 1;
+    // Count first, so a pattern with more components than the inline budget
+    // spills to the heap instead of running off the end of the array.
+    var component_count: usize = 0;
+    {
+        var start: usize = 0;
+        for (effective_pattern, 0..) |ch, idx| {
+            if (isSep(ch)) {
+                if (idx > start) component_count += 1;
+                start = idx + 1;
             }
-            start = idx + 1;
         }
+        if (start < effective_pattern.len) component_count += 1;
     }
-    if (start < effective_pattern.len) {
-        components[component_count] = WildcardComponent.init(effective_pattern[start..], flags);
-        component_count += 1;
+
+    var components_buf: [64]WildcardComponent = undefined;
+    const spilled = component_count > components_buf.len;
+    const components: []WildcardComponent = if (spilled)
+        try allocator.alloc(WildcardComponent, component_count)
+    else
+        components_buf[0..component_count];
+    defer if (spilled) allocator.free(components);
+
+    {
+        var out: usize = 0;
+        var start: usize = 0;
+        for (effective_pattern, 0..) |ch, idx| {
+            if (isSep(ch)) {
+                if (idx > start) {
+                    components[out] = WildcardComponent.init(effective_pattern[start..idx], flags);
+                    out += 1;
+                }
+                start = idx + 1;
+            }
+        }
+        if (start < effective_pattern.len) {
+            components[out] = WildcardComponent.init(effective_pattern[start..], flags);
+            out += 1;
+        }
     }
 
     const estimated_capacity: usize = if (info.has_recursive)
@@ -621,11 +643,11 @@ fn globWithWildcardDirsOptimized(allocator: std.mem.Allocator, pattern: []const 
     else
         ".";
 
-    try expandWildcardComponents(allocator, start_dir, components[0..component_count], 0, &result_paths, directories_only, flags, errfunc, io, base_dir, fs_provider, base_dir, start_dir);
+    try expandWildcardComponents(allocator, start_dir, components, 0, &result_paths, directories_only, flags, errfunc, io, base_dir, fs_provider, base_dir, start_dir);
 
     if (result_paths.len() == 0) {
         if (flags.nocheck) {
-            emitSingleResult(allocator, pzlob, pattern, false) catch return error.OutOfMemory;
+            ResultsList.emitSingle(allocator, pzlob, dooffsSlots(flags, pzlob), pattern, false) catch return error.OutOfMemory;
             return;
         }
         return null;
@@ -812,7 +834,7 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
             const is_dir = if (stat) |s| s.kind == .directory else false;
             if (gi.isIgnored(effective_pattern, is_dir)) {
                 if (flags.nocheck) {
-                    return returnPatternAsResult(allocator, effective_pattern, pzlob);
+                    return returnPatternAsResult(allocator, effective_pattern, flags, pzlob);
                 }
                 return null;
             }
@@ -823,7 +845,7 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
         if (found) return;
 
         if (flags.nocheck) {
-            return returnPatternAsResult(allocator, effective_pattern, pzlob);
+            return returnPatternAsResult(allocator, effective_pattern, flags, pzlob);
         }
 
         return null;
@@ -972,8 +994,8 @@ fn globSingle(allocator: std.mem.Allocator, pattern: []const u8, brace_parsed: ?
     return globInSingleDirWithFnmatch(allocator, filename_pattern, dirname, flags, errfunc, pzlob, info.directories_only, gitignore_filter, brace_parsed, io, base_dir, fs_provider);
 }
 
-fn returnPatternAsResult(allocator: std.mem.Allocator, pattern: []const u8, pzlob: *zlob_t) !?void {
-    try emitSingleResult(allocator, pzlob, pattern, false);
+fn returnPatternAsResult(allocator: std.mem.Allocator, pattern: []const u8, flags: ZlobFlags, pzlob: *zlob_t) !?void {
+    try ResultsList.emitSingle(allocator, pzlob, dooffsSlots(flags, pzlob), pattern, false);
     return;
 }
 
@@ -1102,7 +1124,7 @@ fn globInternalSlice(allocator: std.mem.Allocator, pattern: []const u8, flags: c
     // return the pattern itself as the sole result (like NOCHECK but only
     // when there are no wildcards). See FreeBSD glob.c err_nomatch().
     if (result == null and gf.nomagic and !has_magic) {
-        return returnPatternAsResult(allocator, pattern_slice, pzlob);
+        return returnPatternAsResult(allocator, pattern_slice, gf, pzlob);
     }
 
     return result;
@@ -1150,7 +1172,7 @@ fn globBraceExpand(allocator: std.mem.Allocator, pattern: []const u8, flags: Zlo
 
     if (all_results.len() == 0) {
         if (flags.nocheck) {
-            try emitSingleResult(allocator, pzlob, pattern, false);
+            try ResultsList.emitSingle(allocator, pzlob, dooffsSlots(flags, pzlob), pattern, false);
             return;
         }
         return null;
@@ -1741,7 +1763,7 @@ fn globRecursiveWithBracedPrefix(
 }
 
 fn finalizeResults(allocator: std.mem.Allocator, results: *ResultsList, flags: ZlobFlags, pzlob: *zlob_t) !?void {
-    const offs = if (flags.dooffs) pzlob.zlo_offs else 0;
+    const offs = dooffsSlots(flags, pzlob);
     const new_count = results.len();
 
     // ZLOB_APPEND - merge with existing results. The emit format keeps all
@@ -2100,7 +2122,7 @@ fn globInSingleDirWithFnmatch(allocator: std.mem.Allocator, pattern: []const u8,
 
     if (names.len() == 0) {
         if (flags.nocheck) {
-            emitSingleResult(allocator, pzlob, pattern, false) catch return error.OutOfMemory;
+            ResultsList.emitSingle(allocator, pzlob, dooffsSlots(flags, pzlob), pattern, false) catch return error.OutOfMemory;
             return;
         }
         return null;

--- a/test/test_edge_cases.zig
+++ b/test/test_edge_cases.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const testing = std.testing;
 const zlob = @import("zlob");
 const zlob_flags = @import("zlob_flags");
+const c_lib = @import("c_lib");
 const fnmatch = zlob.fnmatch;
 const test_utils = @import("test_utils");
 const testMatchPathsOnly = test_utils.testMatchPathsOnly;
@@ -160,4 +161,28 @@ test "matchPaths - pattern ending with slash" {
 
     // Should match directory entries ending with /
     try testing.expectEqual(@as(usize, 2), result.len());
+}
+
+test "wildcard pattern with more components than the inline budget" {
+    // globWithWildcardDirsOptimized collects components into a 64-entry stack
+    // array. Anything deeper has to spill to the heap rather than run off the
+    // end of it.
+    var buf: [4096]u8 = undefined;
+    var n: usize = 0;
+    for (0..100) |_| {
+        @memcpy(buf[n..][0..3], "a*/");
+        n += 3;
+    }
+    @memcpy(buf[n..][0..3], "x.c");
+    n += 3;
+    buf[n] = 0;
+    const pattern: [:0]const u8 = buf[0..n :0];
+
+    var pzlob: zlob.zlob_t = std.mem.zeroes(zlob.zlob_t);
+    const result = c_lib.zlob(pattern.ptr, zlob_flags.ZLOB_RECOMMENDED, null, &pzlob);
+    defer c_lib.zlobfree(&pzlob);
+
+    // Nothing on disk is 101 directories deep; the point is that it neither
+    // corrupts the stack nor mis-reports the outcome.
+    try testing.expectEqual(zlob_flags.ZLOB_NOMATCH, result);
 }

--- a/test/test_posix.zig
+++ b/test/test_posix.zig
@@ -292,6 +292,43 @@ test "ZLOB_DOOFFS - works with ZLOB_APPEND" {
     try testing.expect(pzlob.zlo_pathv[1] == null);
 }
 
+// ZLOB_DOOFFS must apply to every result-producing path, not just the ones
+// that go through finalizeResults. POSIX (and glibc) reserve the slots for the
+// ZLOB_NOCHECK pattern echo too, and globfree sizes its free off zlo_offs
+// regardless of which path filled the struct.
+test "ZLOB_DOOFFS - reserves offset slots for the ZLOB_NOCHECK echo" {
+    const allocator = testing.allocator;
+    const pattern = try allocator.dupeZ(u8, "zzz_no_such_file_anywhere_*.nope");
+    defer allocator.free(pattern);
+
+    var pzlob: glob.zlob_t = undefined;
+    pzlob.zlo_offs = 3;
+
+    const result = c_lib.zlob(
+        pattern.ptr,
+        zlob_flags.ZLOB_DOOFFS | zlob_flags.ZLOB_NOCHECK,
+        null,
+        &pzlob,
+    );
+    defer if (result == 0) c_lib.zlobfree(&pzlob);
+
+    try testing.expectEqual(0, result);
+    try testing.expectEqual(@as(usize, 1), pzlob.zlo_pathc);
+
+    // The reserved slots must be present and NULL...
+    try testing.expect(pzlob.zlo_pathv[0] == null);
+    try testing.expect(pzlob.zlo_pathv[1] == null);
+    try testing.expect(pzlob.zlo_pathv[2] == null);
+
+    // ...and the echoed pattern must sit at pathv[offs], where callers look.
+    const echoed = pzlob.zlo_pathv[pzlob.zlo_offs];
+    try testing.expect(echoed != null);
+    try testing.expectEqualStrings(pattern, std.mem.sliceTo(echoed, 0));
+
+    // NULL terminator directly after the single result.
+    try testing.expect(pzlob.zlo_pathv[pzlob.zlo_offs + 1] == null);
+}
+
 // ============================================================================
 // ZLOB_PERIOD - Allow leading '.' to match metacharacters
 // ============================================================================

--- a/test/test_walker_paths.zig
+++ b/test/test_walker_paths.zig
@@ -1,0 +1,179 @@
+//! Path-construction tests for the single-threaded walker (`src/walker.zig`).
+//!
+//! Both backends build entry paths in one shared 4 KiB buffer that sibling
+//! directories overwrite as the walk proceeds, so every pushed directory has
+//! to stash its own path until it is popped. These tests pin that behaviour
+//! for paths long enough to have caught the old fixed 256-byte stash.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const testing = std.testing;
+const walker = @import("walker");
+
+const seg_len = 60;
+const seg = "d" ** seg_len;
+
+const Tree = struct {
+    io: std.Io,
+    root_buf: [256]u8 = undefined,
+    root: []const u8 = &.{},
+
+    fn init(self: *Tree, comptime tag: []const u8) !void {
+        self.io = std.Io.Threaded.global_single_threaded.io();
+        self.root = try std.fmt.bufPrint(&self.root_buf, ".zig-cache/walker-path-tests/{s}_{d}", .{
+            tag,
+            std.Io.Timestamp.now(self.io, .real).toMilliseconds(),
+        });
+        try std.Io.Dir.cwd().createDirPath(self.io, self.root);
+    }
+
+    fn deinit(self: *Tree) void {
+        std.Io.Dir.cwd().deleteTree(self.io, self.root) catch {};
+    }
+
+    fn mkdirs(self: *Tree, rel: []const u8) !void {
+        var buf: [4096]u8 = undefined;
+        const p = try std.fmt.bufPrint(&buf, "{s}/{s}", .{ self.root, rel });
+        try std.Io.Dir.cwd().createDirPath(self.io, p);
+    }
+
+    fn touch(self: *Tree, rel: []const u8) !void {
+        var buf: [4096]u8 = undefined;
+        const p = try std.fmt.bufPrint(&buf, "{s}/{s}", .{ self.root, rel });
+        var f = try std.Io.Dir.cwd().createFile(self.io, p, .{});
+        f.close(self.io);
+    }
+};
+
+/// Walk `root` and return the path reported for the single entry whose
+/// basename is `leaf`, duplicated into `allocator` (Entry.path points into
+/// the walker's own reusable buffer).
+fn findLeaf(
+    comptime be: walker.Backend,
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    root: []const u8,
+    leaf: []const u8,
+) !?[]u8 {
+    var w = try walker.WalkerType(be).init(allocator, io, root, .{ .max_depth = 64 });
+    defer w.deinit();
+    while (try w.next()) |entry| {
+        if (std.mem.eql(u8, entry.basename, leaf)) return try allocator.dupe(u8, entry.path);
+    }
+    return null;
+}
+
+/// Two sibling directories nested deep enough that their paths exceed 256
+/// bytes. Because the stack is LIFO, the second one pushed is popped first and
+/// overwrites the shared path buffer, so the first one's path has to survive
+/// intact rather than keeping a stale tail from its sibling.
+fn deepSiblingsCase(comptime be: walker.Backend) !void {
+    const allocator = testing.allocator;
+
+    var tree: Tree = .{ .io = undefined };
+    try tree.init("deep_siblings");
+    defer tree.deinit();
+
+    const prefix = seg ++ "/" ++ seg ++ "/" ++ seg ++ "/" ++ seg;
+    const a_dir = prefix ++ "/" ++ "a" ** seg_len;
+    const b_dir = prefix ++ "/" ++ "b" ** seg_len;
+
+    try tree.mkdirs(a_dir);
+    try tree.mkdirs(b_dir);
+    try tree.touch(a_dir ++ "/a_leaf.txt");
+    try tree.touch(b_dir ++ "/b_leaf.txt");
+
+    const a_path = try findLeaf(be, allocator, tree.io, tree.root, "a_leaf.txt") orelse
+        return error.LeafNotFound;
+    defer allocator.free(a_path);
+    const b_path = try findLeaf(be, allocator, tree.io, tree.root, "b_leaf.txt") orelse
+        return error.LeafNotFound;
+    defer allocator.free(b_path);
+
+    // Well past the 256-byte stash the getdents64 backend used to truncate at.
+    try testing.expect(a_path.len > 256);
+
+    try testing.expectEqualStrings(a_dir ++ "/a_leaf.txt", a_path);
+    try testing.expectEqualStrings(b_dir ++ "/b_leaf.txt", b_path);
+}
+
+/// A chain deeper than any per-entry stash, walked with no siblings to
+/// clobber the buffer — guards the plain nesting case.
+fn deepChainCase(comptime be: walker.Backend) !void {
+    const allocator = testing.allocator;
+
+    var tree: Tree = .{ .io = undefined };
+    try tree.init("deep_chain");
+    defer tree.deinit();
+
+    const chain = seg ++ "/" ++ seg ++ "/" ++ seg ++ "/" ++ seg ++ "/" ++ seg ++ "/" ++ seg;
+    try tree.mkdirs(chain);
+    try tree.touch(chain ++ "/leaf.txt");
+
+    const path = try findLeaf(be, allocator, tree.io, tree.root, "leaf.txt") orelse
+        return error.LeafNotFound;
+    defer allocator.free(path);
+
+    try testing.expect(path.len > 256);
+    try testing.expectEqualStrings(chain ++ "/leaf.txt", path);
+}
+
+test "std_fs backend: long sibling paths stay intact" {
+    try deepSiblingsCase(.std_fs);
+}
+
+test "std_fs backend: deep chain path stays intact" {
+    try deepChainCase(.std_fs);
+}
+
+test "getdents64 backend: long sibling paths stay intact" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    try deepSiblingsCase(.getdents64);
+}
+
+test "getdents64 backend: deep chain path stays intact" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    try deepChainCase(.getdents64);
+}
+
+// The two backends are meant to be interchangeable, so a tree with mixed
+// name lengths and nesting must produce the exact same set of paths.
+test "backends agree on the entry set" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const allocator = testing.allocator;
+
+    var tree: Tree = .{ .io = undefined };
+    try tree.init("backend_parity");
+    defer tree.deinit();
+
+    const deep = seg ++ "/" ++ seg ++ "/" ++ seg ++ "/" ++ seg ++ "/" ++ seg;
+    try tree.mkdirs(deep);
+    try tree.mkdirs("short/nested");
+    try tree.touch(deep ++ "/deep.txt");
+    try tree.touch("short/nested/file.txt");
+    try tree.touch("short/top.txt");
+
+    var sets: [2]std.ArrayList([]u8) = .{ .empty, .empty };
+    defer for (&sets) |*s| {
+        for (s.items) |p| allocator.free(p);
+        s.deinit(allocator);
+    };
+
+    inline for (.{ walker.Backend.getdents64, walker.Backend.std_fs }, 0..) |be, i| {
+        var w = try walker.WalkerType(be).init(allocator, tree.io, tree.root, .{ .max_depth = 64 });
+        defer w.deinit();
+        while (try w.next()) |entry| {
+            try sets[i].append(allocator, try allocator.dupe(u8, entry.path));
+        }
+    }
+
+    // Traversal order differs between backends; compare as sorted sets.
+    for (&sets) |*s| std.mem.sort([]u8, s.items, {}, struct {
+        fn lt(_: void, a: []u8, b: []u8) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.lt);
+
+    try testing.expectEqual(sets[0].items.len, sets[1].items.len);
+    for (sets[0].items, sets[1].items) |a, b| try testing.expectEqualStrings(a, b);
+}

--- a/test/test_walker_paths.zig
+++ b/test/test_walker_paths.zig
@@ -1,10 +1,4 @@
-//! Path-construction tests for the single-threaded walker (`src/walker.zig`).
-//!
-//! Both backends build entry paths in one shared 4 KiB buffer that sibling
-//! directories overwrite as the walk proceeds, so every pushed directory has
-//! to stash its own path until it is popped. These tests pin that behaviour
-//! for paths long enough to have caught the old fixed 256-byte stash.
-
+// vibe coded based on the path report from fff which was caused by non-libc target
 const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;


### PR DESCRIPTION
Optimizes the glob pipeline end to end, plus two correctness fixes found along the way.

## Benchmarks

Criterion `fs_walk` over a Linux kernel checkout (`rust/benches/glob_comparison.rs`), measured against the base commit. All improvements p=0.00.

| pattern | before | after | change |
|---|---|---|---|
| `fs/*.c` | 16.1 µs | 11.8 µs | **-26.5%** |
| `[fk]*/*.c` | 36.1 µs | 27.0 µs | **-25.3%** |
| `drivers/*/*.c` | 935 µs | 705 µs | **-24.6%** |
| `net/**/*.{c,h}` | 356 µs | 316 µs | **-11.2%** |
| `net/**/*.c` | 349 µs | 314 µs | **-9.9%** |
| `drivers/**/*.c` | 8.72 ms | 8.06 ms | **-7.6%** |
| `**/*.c` | 24.2 ms | 22.7 ms | **-6.0%** |
| `*/Makefile` | 12.6 µs | 12.0 µs | **-4.6%** |
| `**/*.c` +FOLLOW_SYMLINKS | 241 ms | 234 ms | **-3.0%** |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for wildcard patterns with more than 64 path components.
  * Improved traversal of deeply nested paths, including paths longer than 256 characters.
  * Improved compatibility across directory-scanning backends.

* **Bug Fixes**
  * Improved handling of malformed directory entries and high-byte characters.
  * Fixed potential stack corruption with very long wildcard patterns.
  * Improved file-descriptor limit error handling and C API no-match results.

* **Tests**
  * Added coverage for long paths, deep wildcard patterns, and traversal edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->